### PR TITLE
Breaking Change: step signature change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,13 @@ Run one of the built-in pipelines to get a feel for it:
 
   $ pypyr --name echo --context "echoMe=Ceci n'est pas une pipe" --log 20
 
+You can achieve the same thing by running a pipeline where the context is set
+in the pipeline yaml rather than as a --context argument:
+
+.. code-block:: bash
+
+  $ pypyr --name magritte --log 20
+
 
 Run a pipeline
 --------------
@@ -170,9 +177,9 @@ Roll your own context_parser
     logger = pypyr.log.logger.get_logger(__name__)
 
 
-    def get_parsed_context(context):
+    def get_parsed_context(context_string):
         """This is the signature for a context parser. Input context is the string received from pypyr --context 'value here'"""
-        assert context, ("pipeline must be invoked with --context set.")
+        assert context_string, ("pipeline must be invoked with --context set.")
         logger.debug("starting")
 
         # your clever code here. Chances are pretty good you'll be doing things with the input context string to create a dictionary.
@@ -376,8 +383,9 @@ Roll your own step
   import pypyr.log.logger
 
 
-  # use pypyr logger to ensure loglevel is set correctly and logs are formatted nicely
-  # this gets a python logging.Logger type - so you can .warning, .error et.
+  # use pypyr logger to ensure loglevel is set correctly and logs are formatted
+  # nicely. this gets a python logging.Logger type - so you can .warning,
+  # .error et.
   logger = pypyr.log.logger.get_logger(__name__)
 
 
@@ -395,11 +403,12 @@ Roll your own step
       # For .debug() being verbose is very much encouraged.
       logger.info("Your clever code goes here. . . ")
 
+      # Add or edit context items. These are available to any pipeline steps
+      # following this one.
+      context['existingkey'] = 'new value overwrites old value'
+      context['mynewcleverkey'] = 'new value'
+
       logger.debug("done")
-      # it's good form to return the context when you're done with it.
-      # this allows subsequent steps to use the values in the context.
-      # you can obviously add your own values to the context while you're at it.
-      return context
 
 on_success
 ----------

--- a/README.rst
+++ b/README.rst
@@ -177,9 +177,9 @@ Roll your own context_parser
     logger = pypyr.log.logger.get_logger(__name__)
 
 
-    def get_parsed_context(context_string):
+    def get_parsed_context(context_arg):
         """This is the signature for a context parser. Input context is the string received from pypyr --context 'value here'"""
-        assert context_string, ("pipeline must be invoked with --context set.")
+        assert context_arg, ("pipeline must be invoked with --context set.")
         logger.debug("starting")
 
         # your clever code here. Chances are pretty good you'll be doing things with the input context string to create a dictionary.

--- a/pypyr/context/commas.py
+++ b/pypyr/context/commas.py
@@ -12,12 +12,12 @@ import pypyr.log.logger
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context_string):
+def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("pipeline must be invoked with --context set. For "
-                            "this commastolist parser you're looking for "
-                            "something like--context 'spam,eggs' "
-                            "or --context 'spam'.")
+    assert context_arg, ("pipeline must be invoked with --context set. For "
+                         "this commastolist parser you're looking for "
+                         "something like--context 'spam,eggs' "
+                         "or --context 'spam'.")
     logger.debug("starting")
     # for each comma-delimited element, project (element-name, true)
-    return dict((element, True) for element in context_string.split(','))
+    return dict((element, True) for element in context_arg.split(','))

--- a/pypyr/context/commas.py
+++ b/pypyr/context/commas.py
@@ -12,11 +12,12 @@ import pypyr.log.logger
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context):
+def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context, ("pipeline must be invoked with --context set. For this "
-                     "commastolist parser you're looking for something like "
-                     "--context 'spam,eggs' or --context 'spam'.")
+    assert context_string, ("""pipeline must be invoked with --context set. For
+                            this commastolist parser you're looking for
+                            something like--context 'spam,eggs'
+                            or --context 'spam'.""")
     logger.debug("starting")
     # for each comma-delimited element, project (element-name, true)
-    return dict((element, True) for element in context.split(','))
+    return dict((element, True) for element in context_string.split(','))

--- a/pypyr/context/commas.py
+++ b/pypyr/context/commas.py
@@ -14,10 +14,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("""pipeline must be invoked with --context set. For
-                            this commastolist parser you're looking for
-                            something like--context 'spam,eggs'
-                            or --context 'spam'.""")
+    assert context_string, ("pipeline must be invoked with --context set. For "
+                            "this commastolist parser you're looking for "
+                            "something like--context 'spam,eggs' "
+                            "or --context 'spam'.")
     logger.debug("starting")
     # for each comma-delimited element, project (element-name, true)
     return dict((element, True) for element in context_string.split(','))

--- a/pypyr/context/json.py
+++ b/pypyr/context/json.py
@@ -7,13 +7,13 @@ import json
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context_string):
+def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("pipeline must be invoked with --context set. For "
-                            "this json parser you're looking for something "
-                            "like "
-                            "--context '{\"key1\":\"value1\","
-                            "\"key2\":\"value2\"}'")
+    assert context_arg, ("pipeline must be invoked with --context set. For "
+                         "this json parser you're looking for something "
+                         "like "
+                         "--context '{\"key1\":\"value1\","
+                         "\"key2\":\"value2\"}'")
     logger.debug("starting")
     # deserialize the input context string into json
-    return json.loads(context_string)
+    return json.loads(context_arg)

--- a/pypyr/context/json.py
+++ b/pypyr/context/json.py
@@ -7,11 +7,11 @@ import json
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context):
+def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context, ("""pipeline must be invoked with --context set. For this "
-                     "json parser you're looking for something like "
-                     "--context '{"key1":"value1","key2":"value2"}'""")
+    assert context_string, ("""pipeline must be invoked with --context set. For
+                            this json parser you're looking for something like
+                            --context '{"key1":"value1","key2":"value2"}'""")
     logger.debug("starting")
     # deserialize the input context string into json
-    return json.loads(context)
+    return json.loads(context_string)

--- a/pypyr/context/json.py
+++ b/pypyr/context/json.py
@@ -9,9 +9,11 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("""pipeline must be invoked with --context set. For
-                            this json parser you're looking for something like
-                            --context '{"key1":"value1","key2":"value2"}'""")
+    assert context_string, ("pipeline must be invoked with --context set. For "
+                            "this json parser you're looking for something "
+                            "like "
+                            "--context '{\"key1\":\"value1\","
+                            "\"key2\":\"value2\"}'")
     logger.debug("starting")
     # deserialize the input context string into json
     return json.loads(context_string)

--- a/pypyr/context/jsonfile.py
+++ b/pypyr/context/jsonfile.py
@@ -9,9 +9,9 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("""pipeline must be invoked with --context set. For
-                               this json parser you're looking for something
-                               like --context './myjsonfile.json'""")
+    assert context_string, ("pipeline must be invoked with --context set. For "
+                            "this json parser you're looking for something "
+                            "like --context './myjsonfile.json'")
     logger.debug("starting")
     # open the json file on disk so that you can initialize the dictionary
     logger.debug(f"attempting to open file: {context_string}")

--- a/pypyr/context/jsonfile.py
+++ b/pypyr/context/jsonfile.py
@@ -7,15 +7,15 @@ import json
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context):
+def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context, ("""pipeline must be invoked with --context set. For this "
-                     "json parser you're looking for something like "
-                     "--context './myjsonfile.json'""")
+    assert context_string, ("""pipeline must be invoked with --context set. For
+                               this json parser you're looking for something
+                               like --context './myjsonfile.json'""")
     logger.debug("starting")
     # open the json file on disk so that you can initialize the dictionary
-    logger.debug(f"attempting to open file: {context}")
-    with open(context) as json_file:
+    logger.debug(f"attempting to open file: {context_string}")
+    with open(context_string) as json_file:
         payload = json.load(json_file)
 
     logger.debug(f"json file loaded into context. Count: {len(payload)}")

--- a/pypyr/context/jsonfile.py
+++ b/pypyr/context/jsonfile.py
@@ -7,15 +7,15 @@ import json
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context_string):
+def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("pipeline must be invoked with --context set. For "
-                            "this json parser you're looking for something "
-                            "like --context './myjsonfile.json'")
+    assert context_arg, ("pipeline must be invoked with --context set. For "
+                         "this json parser you're looking for something "
+                         "like --context './myjsonfile.json'")
     logger.debug("starting")
     # open the json file on disk so that you can initialize the dictionary
-    logger.debug(f"attempting to open file: {context_string}")
-    with open(context_string) as json_file:
+    logger.debug(f"attempting to open file: {context_arg}")
+    with open(context_arg) as json_file:
         payload = json.load(json_file)
 
     logger.debug(f"json file loaded into context. Count: {len(payload)}")

--- a/pypyr/context/keyvaluepairs.py
+++ b/pypyr/context/keyvaluepairs.py
@@ -12,12 +12,12 @@ import pypyr.log.logger
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context_string):
+def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("pipeline must be invoked with --context set. For "
-                            "this keyvaluepairs parser you're looking for "
-                            "something like "
-                            "--context 'key1=value1,key2=value2'.")
+    assert context_arg, ("pipeline must be invoked with --context set. For "
+                         "this keyvaluepairs parser you're looking for "
+                         "something like "
+                         "--context 'key1=value1,key2=value2'.")
     logger.debug("starting")
     # for each comma-delimited element, project key=value
-    return dict(element.split('=') for element in context_string.split(','))
+    return dict(element.split('=') for element in context_arg.split(','))

--- a/pypyr/context/keyvaluepairs.py
+++ b/pypyr/context/keyvaluepairs.py
@@ -14,10 +14,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context_string, ("""pipeline must be invoked with --context set. For
-                            this keyvaluepairs parser you're looking for
-                            something like
-                            --context 'key1=value1,key2=value2'.""")
+    assert context_string, ("pipeline must be invoked with --context set. For "
+                            "this keyvaluepairs parser you're looking for "
+                            "something like "
+                            "--context 'key1=value1,key2=value2'.")
     logger.debug("starting")
     # for each comma-delimited element, project key=value
     return dict(element.split('=') for element in context_string.split(','))

--- a/pypyr/context/keyvaluepairs.py
+++ b/pypyr/context/keyvaluepairs.py
@@ -12,11 +12,12 @@ import pypyr.log.logger
 logger = pypyr.log.logger.get_logger(__name__)
 
 
-def get_parsed_context(context):
+def get_parsed_context(context_string):
     """Parse input context string and returns context as dictionary."""
-    assert context, ("pipeline must be invoked with --context set. For this "
-                     "keyvaluepairs parser you're looking for something like "
-                     "--context 'key1=value1,key2=value2'.")
+    assert context_string, ("""pipeline must be invoked with --context set. For
+                            this keyvaluepairs parser you're looking for
+                            something like
+                            --context 'key1=value1,key2=value2'.""")
     logger.debug("starting")
     # for each comma-delimited element, project key=value
-    return dict(element.split('=') for element in context.split(','))
+    return dict(element.split('=') for element in context_string.split(','))

--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -51,9 +51,9 @@ def get_pipeline_path(pipeline_name, working_directory):
     if os.path.isfile(pipeline_path):
         logger.debug(f"Found {pipeline_path}")
     else:
-        logger.debug(f"""{pipeline_name} not found in current
-        directory/pipelines folder. Looking in pypyr install directory
-        instead.""")
+        logger.debug(f"{pipeline_name} not found in current "
+                     "directory/pipelines folder. Looking in pypyr install "
+                     "directory instead.")
         pypyr_dir = os.path.dirname(os.path.abspath(__file__))
         logger.debug(f"pypyr installation directory is: {pypyr_dir}")
         pipeline_path = os.path.abspath(os.path.join(
@@ -64,8 +64,9 @@ def get_pipeline_path(pipeline_name, working_directory):
         if os.path.isfile(pipeline_path):
             logger.debug(f"Found {pipeline_path}")
         else:
-            raise FileNotFoundError(f"""{pipeline_name}.yaml not found in
-            either {working_directory}/pipelines or {pypyr_dir}/pipelines""")
+            raise FileNotFoundError(f"{pipeline_name}.yaml not found in "
+                                    f"either {working_directory}/pipelines or "
+                                    f"{pypyr_dir}/pipelines")
 
     logger.debug("done")
     return pipeline_path

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -28,14 +28,19 @@ def get_parsed_context(pipeline, context_in_string):
             logger.debug(f"step {parser_module_name} done")
             # Downstream steps likely to expect context not to be None, hence
             # empty rather than None.
-            return {} if result_context is None else result_context
+            if result_context is None:
+                logger.debug(f"{parser_module_name} returned None. Using "
+                             "empty context instead")
+                return {}
+            else:
+                return result_context
         except AttributeError:
             logger.error(f"The parser {parser_module_name} doesn't have a "
                          "get_parsed_context(context) function.")
             raise
     else:
-        logger.debug(
-            "pipeline does not have custom context parser. Return None.")
+        logger.debug("pipeline does not have custom context parser. Using "
+                     "empty context.")
         logger.debug("done")
         # initialize to an empty dictionary because you want to be able to run
         # with no context.

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -117,8 +117,9 @@ def main(pipeline_name, pipeline_context_input, working_dir, log_level):
         # yes, yes, don't catch Exception. Have to, though, to run the failure
         # handler. Also, it does raise it back up.
         logger.error("Something went wrong. Will now try to run on_failure.")
-        # use the input context, because context_out prob doesn't have a value
-        # yet.
+        # if something went wrong with pipeline loading there will likely be
+        # another exception here because it's looking for failure steps in the
+        # pipeline, but the failure_step_group will swallow it.
         pypyr.stepsrunner.run_failure_step_group(
             pipeline=pipeline_definition,
             context=parsed_context)

--- a/pypyr/steps/contextset.py
+++ b/pypyr/steps/contextset.py
@@ -45,4 +45,3 @@ def run_step(context):
         context[k] = context[v]
 
     logger.debug("done")
-    return context

--- a/pypyr/steps/echo.py
+++ b/pypyr/steps/echo.py
@@ -22,4 +22,3 @@ def run_step(context):
     logger.info(context['echoMe'])
 
     logger.debug("done")
-    return context

--- a/pypyr/steps/py.py
+++ b/pypyr/steps/py.py
@@ -41,4 +41,3 @@ def run_step(context):
         pass
 
     logger.debug("done")
-    return context

--- a/pypyr/steps/pypyrversion.py
+++ b/pypyr/steps/pypyrversion.py
@@ -13,4 +13,3 @@ def run_step(context):
     logger.info(f"pypyr version is: {pypyr.version.get_version()}")
 
     logger.debug("done")
-    return context

--- a/pypyr/steps/safeshell.py
+++ b/pypyr/steps/safeshell.py
@@ -35,4 +35,3 @@ def run_step(context):
     subprocess.run(args, shell=False, check=True)
 
     logger.debug("done")
-    return context

--- a/pypyr/steps/shell.py
+++ b/pypyr/steps/shell.py
@@ -37,4 +37,3 @@ def run_step(context):
     subprocess.run(context['cmd'], shell=True, check=True)
 
     logger.debug("done")
-    return context

--- a/tests/unit/pypyr/steps/contextset_test.py
+++ b/tests/unit/pypyr/steps/contextset_test.py
@@ -17,7 +17,7 @@ def test_context_set_throws_on_contextset_missing():
 
 def test_context_set_pass():
     """contextset success case"""
-    context_in = {
+    context = {
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
@@ -27,7 +27,7 @@ def test_context_set_pass():
         }
     }
 
-    context = pypyr.steps.contextset.run_step(context_in)
+    pypyr.steps.contextset.run_step(context)
 
     assert context['key1'] == 'value1'
     assert context['key2'] == 'value1'

--- a/tests/unit/pypyr/steps/py_test.py
+++ b/tests/unit/pypyr/steps/py_test.py
@@ -30,8 +30,8 @@ def test_py_sequence_with_semicolons():
     pypyr.steps.py.run_step(context)
 
     assert context == {'pycode':
-                       'print(1); print(2); print(3);'}, ("""context in and out
-                                                             the same""")
+                       'print(1); print(2); print(3);'}, ("context in and out "
+                                                          "the same")
 
 
 def test_py_sequence_with_linefeeds():

--- a/tests/unit/pypyr/steps/py_test.py
+++ b/tests/unit/pypyr/steps/py_test.py
@@ -12,13 +12,13 @@ def test_py_single_code():
 def test_py_sequence():
     """Sequence of py code works and touches context."""
     context = {'pycode': "context['test'] = 1;"}
-    context = pypyr.steps.py.run_step(context)
+    pypyr.steps.py.run_step(context)
 
     context.update({'pycode': "context['test'] += 2"})
-    context = pypyr.steps.py.run_step(context)
+    pypyr.steps.py.run_step(context)
 
     context.update({'pycode': "context['test'] += 3"})
-    context = pypyr.steps.py.run_step(context)
+    pypyr.steps.py.run_step(context)
 
     assert context['test'] == 6, "context should be 6 at this point"
 
@@ -27,32 +27,36 @@ def test_py_sequence_with_semicolons():
     """Single py code string with semi - colons works."""
     context = {'pycode':
                'print(1); print(2); print(3);'}
-    context = pypyr.steps.py.run_step(context)
+    pypyr.steps.py.run_step(context)
+
+    assert context == {'pycode':
+                       'print(1); print(2); print(3);'}, ("""context in and out
+                                                             the same""")
 
 
 def test_py_sequence_with_linefeeds():
     """Single py code string with linefeeds works."""
     context = {'pycode':
                'print(1)\nprint(2)\nprint(3)'}
-    context = pypyr.steps.py.run_step(context)
+    pypyr.steps.py.run_step(context)
 
 
 def test_pycode_error_throws():
     """pycode error should raise up to caller."""
     with pytest.raises(AssertionError):
         context = {'pycode': 'assert False'}
-        context = pypyr.steps.py.run_step(context)
+        pypyr.steps.py.run_step(context)
 
 
 def test_no_pycode_context_throw():
     """No pycode in context should throw assert error."""
     with pytest.raises(AssertionError):
         context = {'blah': 'blah blah'}
-        context = pypyr.steps.py.run_step(context)
+        pypyr.steps.py.run_step(context)
 
 
 def test_empty_pycode_context_throw():
     """Empty pycode in context should throw assert error."""
     with pytest.raises(AssertionError):
         context = {'pycode': None}
-        context = pypyr.steps.py.run_step(context)
+        pypyr.steps.py.run_step(context)

--- a/tests/unit/pypyr/steps/pypyrversion_test.py
+++ b/tests/unit/pypyr/steps/pypyrversion_test.py
@@ -8,5 +8,6 @@ def test_pypyr_version():
 
 
 def test_pypyr_version_context_out_same_as_in():
-    context = pypyr.steps.pypyrversion.run_step({'test': 'value1'})
+    context = {'test': 'value1'}
+    pypyr.steps.pypyrversion.run_step(context)
     assert context['test'] == 'value1', "context not returned from step."


### PR DESCRIPTION
- From now on a pipeline context is always a dictionary. - Simple is better than complex
- a pipeline step's  `def run_step(context)` used to require a return type `return context`. This is a hang-over from the early days of pypyr where I was still thinking that a context could by anything - a plain old string, or a dictionary, or a stream (file-like objects in pythonese), or a whatever. 
  - So if the `run_step(context)` was to be an immutable type (e.g a string), then any alterations to the context inside the run_step wouldn't have made it back out of the func unless _explicitly_ returned as a new obj `return mymanipulatedblah`. Hence the 1st design with the explicit return required.
  - Given the heavy preponderance of mutable dictionary usage for the context for pretty much everything, and given that the dictionary-like context can contain any of the different types listed above (plain old string, dictionary containing dictionaries, dictionary containing lists, or file-like objs), I'm having a hard-time justifying the extra effort to deal with the vague theory that "just maybe" someone just wants to use a plain string as a context for the entire pipeline beginning to end. 
- It also feels gnarly for the end-user to have to remember to have a `return context` at the end of his custom pipeline step code. The new way is more pythonic - from the zen of python:
 
> There should be one-- and preferably only one --obvious way to do it.
> Although that way may not be obvious at first unless you're Dutch.
  - making the change now before the pypyr-blah plugins get published, so their signatures can be right from the start.
- PR also reformats a bunch of triple-quote comments to use implied multi line concat instead, plus minor README updates et.
- pypyr-example updated with the same as above to account for signature change