### PR TITLE
String Interpolation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,34 +88,34 @@ Pipeline yaml structure
 A pipeline is a .yaml file. Save pipelines to a `pipelines` directory in your
 working directory.
 
-  .. code-block:: yaml
+.. code-block:: yaml
 
-    # This is an example showing the anatomy of a pypyr pipeline
-    # A pipeline should be saved as {working dir}/pipelines/mypipelinename.yaml.
-    # Run the pipeline from {working dir} like this: pypyr --name mypipelinename
+  # This is an example showing the anatomy of a pypyr pipeline
+  # A pipeline should be saved as {working dir}/pipelines/mypipelinename.yaml.
+  # Run the pipeline from {working dir} like this: pypyr --name mypipelinename
 
-    # optional
-    context_parser: my.custom.parser
+  # optional
+  context_parser: my.custom.parser
 
-    # mandatory.
-    steps:
-      - my.package.my.module # simple step pointing at a python module in a package
-      - mymodule # simple step pointing at a python file
-      - name: my.package.another.module # complex step. It contains a description and in parameters.
-        description: Optional description is for humans. It's any text that makes your life easier.
-        in: #optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
-          parameter1: value1
-          parameter2: value2
+  # mandatory.
+  steps:
+    - my.package.my.module # simple step pointing at a python module in a package
+    - mymodule # simple step pointing at a python file
+    - name: my.package.another.module # complex step. It contains a description and in parameters.
+      description: Optional description is for humans. It's any text that makes your life easier.
+      in: #optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
+        parameter1: value1
+        parameter2: value2
 
-    # optional.
-    on_success:
-      - my.first.success.step
-      - my.second.success.step
+  # optional.
+  on_success:
+    - my.first.success.step
+    - my.second.success.step
 
-    # optional.
-    on_failure:
-      - my.failure.handler.step
-      - my.failure.handler.notifier
+  # optional.
+  on_failure:
+    - my.failure.handler.step
+    - my.failure.handler.notifier
 
 Built-in pipelines
 ------------------
@@ -177,25 +177,25 @@ Built-in context parsers
 
 Roll your own context_parser
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  .. code-block:: python
+.. code-block:: python
 
-    import logging
-
-
-    # getLogger will grab the parent logger context, so your loglevel and
-    # formatting will inherit correctly automatically from the pypyr core.
-    logger = logging.getLogger(__name__)
+  import logging
 
 
-    def get_parsed_context(context_arg):
-        """This is the signature for a context parser. Input context is the string received from pypyr --context 'value here'"""
-        assert context_arg, ("pipeline must be invoked with --context set.")
-        logger.debug("starting")
+  # getLogger will grab the parent logger context, so your loglevel and
+  # formatting will inherit correctly automatically from the pypyr core.
+  logger = logging.getLogger(__name__)
 
-        # your clever code here. Chances are pretty good you'll be doing things with the input context string to create a dictionary.
 
-        # function signature returns a dictionary
-        return {'key1': 'value1', 'key2':'value2'}
+  def get_parsed_context(context_arg):
+      """This is the signature for a context parser. Input context is the string received from pypyr --context 'value here'"""
+      assert context_arg, ("pipeline must be invoked with --context set.")
+      logger.debug("starting")
+
+      # your clever code here. Chances are pretty good you'll be doing things with the input context string to create a dictionary.
+
+      # function signature returns a dictionary
+      return {'key1': 'value1', 'key2':'value2'}
 
 steps
 -----
@@ -253,31 +253,31 @@ If you run newKey: currentKey, you'll end up with `context['newKey'] == 'eggs'`
 
 For example, say your context looks like this,
 
-  .. code-block:: yaml
+.. code-block:: yaml
 
-        key1: value1
-        key2: value2
-        key3: value3
+      key1: value1
+      key2: value2
+      key3: value3
 
 and your pipeline yaml looks like this:
 
-  .. code-block:: yaml
+.. code-block:: yaml
 
-    steps:
-      - name: pypyr.steps.contextset
-        in:
-          contextSet:
-            key2: key1
-            key4: key3
+  steps:
+    - name: pypyr.steps.contextset
+      in:
+        contextSet:
+          key2: key1
+          key4: key3
 
 This will result in context like this:
 
-  .. code-block:: yaml
+.. code-block:: yaml
 
-      key1: value1
-      key2: value1
-      key3: value3
-      key4: value3
+    key1: value1
+    key2: value1
+    key3: value3
+    key4: value3
 
 pypyr.steps.echo
 ````````````````
@@ -285,17 +285,17 @@ Echo the context value `echoMe` to the output.
 
 For example, if you had pipelines/mypipeline.yaml like this:
 
-  .. code-block:: yaml
+.. code-block:: yaml
 
-    context_parser: pypyr.context.keyvaluepairs
-    steps:
-      - name: pypyr.steps.echo
+  context_parser: pypyr.context.keyvaluepairs
+  steps:
+    - name: pypyr.steps.echo
 
 You can run:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    pypyr --name mypipeline --context 'echoMe=test test test'
+  pypyr --name mypipeline --context 'echoMe=test test test'
 
 
 Alternatively, if you had pipelines/look-ma-no-params.yaml like this:
@@ -311,9 +311,9 @@ Alternatively, if you had pipelines/look-ma-no-params.yaml like this:
 
 You can run:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    $ pypyr --name look-ma-no-params --log 20
+  $ pypyr --name look-ma-no-params --log 20
 
 pypyr.steps.py
 ``````````````
@@ -322,8 +322,8 @@ Executes the context value `pycode` as python code.
 Will exec context['pycode'] as a dynamically interpreted python code block.
 
 You can access and change the context dictionary in a py step. See a worked
-example here:
-https://github.com/pypyr/pypyr-example/tree/master/pipelines/py.yaml
+example `here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/py.yaml>`_.
 
 For example, this will invoke python print and print 2:
 
@@ -339,19 +339,19 @@ pypyr.steps.pypyrversion
 ````````````````````````
 Outputs the same as:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    pypyr --version
+  pypyr --version
 
 This is an actual pipeline, though, so unlike --version, it'll use the standard
 pypyr logging format.
 
 Example pipeline yaml:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-      steps:
-        - pypyr.steps.pypyrversion
+    steps:
+      - pypyr.steps.pypyrversion
 
 pypyr.steps.safeshell
 `````````````````````
@@ -363,20 +363,20 @@ wildcards, environment variable expansion, and expansion of ~ to a user’s
 home directory. Use pypyr.steps.shell for this instead.
 
 You can use context variable substitutions with curly braces. See a worked
-example here:
-https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml
+example `for substitions here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`_.
 
 Escape literal curly braces with doubles: {{ for {, }} for }
 
 
 Example pipeline yaml:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    steps:
-      - name: pypyr.steps.safeshell
-        in:
-          cmd: ls -a
+  steps:
+    - name: pypyr.steps.safeshell
+      in:
+        cmd: ls -a
 
 pypyr.steps.shell
 `````````````````````
@@ -392,19 +392,19 @@ Friendly reminder of the difference between separating your commands with ; or
 - && stops and exits reporting error on first error.
 
 You can use context variable substitutions with curly braces. See a worked
-example here:
-https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml
+example `for substitions here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`_.
 
 Escape literal curly braces with doubles: {{ for {, }} for }
 
 Example pipeline yaml using a pipe:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    steps:
-      - name: pypyr.steps.shell
-        in:
-          cmd: ls | grep pipe; echo if you had something pipey it should show up;
+  steps:
+    - name: pypyr.steps.shell
+      in:
+        cmd: ls | grep pipe; echo if you had something pipey it should show up;
 
 Roll your own step
 ~~~~~~~~~~~~~~~~~~
@@ -464,12 +464,12 @@ Testing without worrying about dependencies
 -------------------------------------------
 Run tox to test the packaging cycle inside a virtual env, plus run all tests:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-    # just run tests
-    $ tox -e dev -- tests
-    # run tests, validate README.rst, run flake8 linter
-    $ tox -e stage -- tests
+  # just run tests
+  $ tox -e dev -- tests
+  # run tests, validate README.rst, run flake8 linter
+  $ tox -e stage -- tests
 
 If tox takes too long
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,9 @@ Built-in context parsers
 | pypyr.context.commas        | Takes a comma delimited string and returns a    |`pypyr --name pipelinename --context "param1,param2,param3"`                         |
 |                             | dictionary where each element becomes the key,  |                                                                                     |
 |                             | with value to true.                             |This will create a context dictionary like this:                                     |
-|                             |                                                 |{'param1': True, 'param2': True, 'param3': True}                                     |
+|                             | Don't have spaces between commas unless you     |{'param1': True, 'param2': True, 'param3': True}                                     |
+|                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
+|                             | a context key name of \' k2\' not \'k2\'.       |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | pypyr.context.json          | Takes a json string and returns a dictionary.   |`pypyr --name pipelinename --context \'{"key1":"value1","key2":"value2"}\'`          |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
@@ -167,6 +169,9 @@ Built-in context parsers
 | pypyr.context.keyvaluepairs | Takes a comma delimited key=value pair string   |`pypyr --name pipelinename --context "param1=value1,param2=value2,param3=value3"`    |
 |                             | and returns a dictionary where each pair becomes|                                                                                     |
 |                             | a dictionary element.                           |                                                                                     |
+|                             | Don't have spaces between commas unless you     |                                                                                     |
+|                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
+|                             | a context key name of \' k2\' not \'k2\'.       |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 
 
@@ -355,7 +360,14 @@ Runs the context value `cmd` in the default shell. On a sensible O/S, this is
 
 In `safeshell`, you cannot use things like exit, return, shell pipes, filename
 wildcards, environment variable expansion, and expansion of ~ to a user’s
-home directory.
+home directory. Use pypyr.steps.shell for this instead.
+
+You can use context variable substitutions with curly braces. See a worked
+example here:
+https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml
+
+Escape literal curly braces with doubles: {{ for {, }} for }
+
 
 Example pipeline yaml:
 
@@ -371,6 +383,19 @@ pypyr.steps.shell
 Runs the context value `cmd` in the default shell.
 
 Do all the things you can't do with `safeshell`.
+
+Friendly reminder of the difference between separating your commands with ; or
+&&:
+
+- ; will continue to the next statement even if the previous command errored.
+  It won't exit with an error code if it wasn't the last statement.
+- && stops and exits reporting error on first error.
+
+You can use context variable substitutions with curly braces. See a worked
+example here:
+https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml
+
+Escape literal curly braces with doubles: {{ for {, }} for }
 
 Example pipeline yaml using a pipe:
 

--- a/README.rst
+++ b/README.rst
@@ -364,7 +364,7 @@ home directory. Use pypyr.steps.shell for this instead.
 
 You can use context variable substitutions with curly braces. See a worked
 example `for substitions here
-<https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`_.
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`__.
 
 Escape literal curly braces with doubles: {{ for {, }} for }
 
@@ -393,7 +393,7 @@ Friendly reminder of the difference between separating your commands with ; or
 
 You can use context variable substitutions with curly braces. See a worked
 example `for substitions here
-<https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`_.
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`__.
 
 Escape literal curly braces with doubles: {{ for {, }} for }
 

--- a/pypyr/context/keyvaluepairs.py
+++ b/pypyr/context/keyvaluepairs.py
@@ -3,6 +3,9 @@
 Takes a comma delimited key=value pair string and returns a dictionary where
 each pair becomes a dictionary element.
 
+Don't have spaces between commas unless your really mean it. "k1=v1, k2=v2"
+will result in a context key name of ' k2' not 'k2'.
+
 So a string like this "pig=ham,hen=eggs,yummypig=bacon", will yield:
 {'pig': 'ham', 'hen': ''eggs', 'yummypig': 'bacon'}
 """

--- a/pypyr/format/__init__.py
+++ b/pypyr/format/__init__.py
@@ -1,0 +1,1 @@
+"""init py module."""

--- a/pypyr/format/string.py
+++ b/pypyr/format/string.py
@@ -1,0 +1,24 @@
+"""pypyr string formatting."""
+
+
+def get_interpolated_string(input_string, context):
+    """Return a string interpolated from the context dictionary.
+
+    If input_string='Piping {key1} the {key2} wild'
+    And context={'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
+
+    Then this will return string: "Piping down the valleys wild"
+
+    Args:
+        input_string: string literal to evaluate.
+        context: dictionary. will interpolate input_string based on finding
+                 keys in curly braces {} in input_string.
+
+    Returns:
+        string
+
+    Raises:
+        KeyError: if input_string has {key} where key does not exist in
+                  context dictionary.
+    """
+    return input_string.format(**context)

--- a/pypyr/steps/safeshell.py
+++ b/pypyr/steps/safeshell.py
@@ -36,16 +36,14 @@ def run_step(context):
                      "--context 'cmd=<<shell cmd here>>'?")
     assert 'cmd' in context, ("context['cmd'] must exist for step shell.")
 
-    logger.debug(f"Executing command string: {context['cmd']}")
+    logger.debug(f"Processing command string: {context['cmd']}")
     interpolated_string = pypyr.format.string.get_interpolated_string(
         input_string=context['cmd'],
         context=context)
-    logger.debug(f"Interpolated string: {interpolated_string}")
 
     # input string is a command like 'ls -l | grep boom'. Split into list on
     # spaces to allow for natural shell language input string.
     args = interpolated_string.split(' ')
-    logger.debug(f"Prepared command sequence: {args}")
 
     # check=True throws CalledProcessError if exit code != 0
     subprocess.run(args, shell=False, check=True)

--- a/pypyr/steps/shell.py
+++ b/pypyr/steps/shell.py
@@ -4,6 +4,7 @@ The context['cmd'] string must be formatted exactly as it would be when typed
 at the shell prompt. This includes, for example, quoting or backslash escaping
 filenames with spaces in them. The shell defaults to /bin/sh.
 """
+import pypyr.format.string
 import pypyr.log.logger
 import subprocess
 
@@ -20,9 +21,19 @@ def run_step(context):
     The context['cmd'] string must be formatted exactly as it would be when
     typed at the shell prompt. This includes, for example, quoting or backslash
     escaping filenames with spaces in them.
+    There is an exception to this: Escape curly braces: if you want a literal
+    curly brace, double it like {{ or }}.
 
     context is mandatory. When you execute the pipeline, it should look
     something like this: pipeline-runner [name here] --context 'cmd=ls -a'.
+
+    context['cmd'] will interpolate anything in curly braces for values
+    found in context. So if your context looks like this:
+        key1: value1
+        key2: value2
+        cmd: mything --arg1 {key1}
+
+    The cmd passed to the shell will be "mything --arg value1"
     """
     logger.debug("started")
     assert context, ("context must be set for step shell. Did you set "
@@ -33,7 +44,12 @@ def run_step(context):
     # spaces to allow for natural shell language input string.
     logger.debug(f"Executing command string: {context['cmd']}")
 
+    interpolated_string = pypyr.format.string.get_interpolated_string(
+        input_string=context['cmd'],
+        context=context)
+    logger.debug(f"Interpolated string: {interpolated_string}")
+
     # check=True throws CalledProcessError if exit code != 0
-    subprocess.run(context['cmd'], shell=True, check=True)
+    subprocess.run(interpolated_string, shell=True, check=True)
 
     logger.debug("done")

--- a/pypyr/steps/shell.py
+++ b/pypyr/steps/shell.py
@@ -42,12 +42,11 @@ def run_step(context):
 
     # input string is a command like 'ls -l | grep boom'. Split into list on
     # spaces to allow for natural shell language input string.
-    logger.debug(f"Executing command string: {context['cmd']}")
+    logger.debug(f"Processing command string: {context['cmd']}")
 
     interpolated_string = pypyr.format.string.get_interpolated_string(
         input_string=context['cmd'],
         context=context)
-    logger.debug(f"Interpolated string: {interpolated_string}")
 
     # check=True throws CalledProcessError if exit code != 0
     subprocess.run(interpolated_string, shell=True, check=True)

--- a/shippable.yaml
+++ b/shippable.yaml
@@ -7,7 +7,6 @@ python:
 build:
   ci:
       # Shippable uses special folders for test and cov reports. Dist is for twine.
-    - ls -l /tmp/ssh/
     - mkdir -p dist
     - mkdir -p shippable/testresults
     - mkdir -p shippable/codecoverage

--- a/tests/unit/pypyr/format/string_test.py
+++ b/tests/unit/pypyr/format/string_test.py
@@ -1,0 +1,28 @@
+""""string.py unit tests."""
+
+import pypyr.format.string
+import pytest
+
+
+def test_string_interpolate_works():
+    context = {'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
+    input_string = 'Piping {key1} the {key2} wild'
+    output = pypyr.format.string.get_interpolated_string(input_string, context)
+    assert output == 'Piping down the valleys wild', (
+        "string interpolation incorrect")
+
+
+def test_string_interpolate_works_with_no_swaps():
+    context = {'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
+    input_string = 'Piping down the valleys wild'
+    output = pypyr.format.string.get_interpolated_string(input_string, context)
+    assert output == 'Piping down the valleys wild', (
+        "string interpolation incorrect")
+
+
+def test_tag_not_in_context_should_throw():
+    """pycode error should raise up to caller."""
+    with pytest.raises(KeyError):
+        context = {'key1': 'value1'}
+        input_string = '{key1} this is {key2} string'
+        pypyr.format.string.get_interpolated_string(input_string, context)

--- a/tests/unit/pypyr/format/string_test.py
+++ b/tests/unit/pypyr/format/string_test.py
@@ -20,6 +20,30 @@ def test_string_interpolate_works_with_no_swaps():
         "string interpolation incorrect")
 
 
+def test_string_interpolate_escapes_double_curly():
+    context = {'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
+    input_string = 'Piping {{ down the valleys wild'
+    output = pypyr.format.string.get_interpolated_string(input_string, context)
+    assert output == 'Piping { down the valleys wild', (
+        "string interpolation incorrect")
+
+
+def test_string_interpolate_escapes_double_curly_pair():
+    context = {'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
+    input_string = 'Piping {{down}} the valleys wild'
+    output = pypyr.format.string.get_interpolated_string(input_string, context)
+    assert output == 'Piping {down} the valleys wild', (
+        "string interpolation incorrect")
+
+
+def test_single_curly_should_throw():
+    """pycode error should raise up to caller."""
+    with pytest.raises(ValueError):
+        context = {'key1': 'value1'}
+        input_string = '{key1} this { is {key2} string'
+        pypyr.format.string.get_interpolated_string(input_string, context)
+
+
 def test_tag_not_in_context_should_throw():
     """pycode error should raise up to caller."""
     with pytest.raises(KeyError):

--- a/tests/unit/pypyr/steps/safeshell_test.py
+++ b/tests/unit/pypyr/steps/safeshell_test.py
@@ -22,6 +22,20 @@ def test_shell_sequence():
     context = pypyr.steps.safeshell.run_step(context)
 
 
+def test_shell_sequence_with_string_interpolation():
+    """Single shell command string works with string interpolation."""
+    context = {'fileName': 'deleteinterpolatedme.arb',
+               'cmd': 'touch {fileName}'}
+    context = pypyr.steps.safeshell.run_step(context)
+
+    context = {'cmd': 'ls deleteinterpolatedme.arb'}
+    context = pypyr.steps.safeshell.run_step(context)
+
+    context = {'fileName': 'deleteinterpolatedme.arb',
+               'cmd': 'rm -f {fileName}'}
+    context = pypyr.steps.safeshell.run_step(context)
+
+
 def test_shell_error_throws():
     """Shell process returning 1 should throw CalledProcessError"""
     with pytest.raises(subprocess.CalledProcessError):

--- a/tests/unit/pypyr/steps/shell_test.py
+++ b/tests/unit/pypyr/steps/shell_test.py
@@ -29,6 +29,14 @@ def test_shell_sequence_with_semicolons():
     context = pypyr.steps.shell.run_step(context)
 
 
+def test_shell_sequence_with_string_interpolation():
+    """Single shell command string works with string interpolation."""
+    context = {'fileName': 'deleteme.arb',
+               'cmd':
+               'touch {fileName} && ls deleteme.arb && rm -f deleteme.arb;'}
+    context = pypyr.steps.shell.run_step(context)
+
+
 def test_shell_sequence_with_ampersands():
     """Single shell command string with ampersands works."""
     context = {'cmd':


### PR DESCRIPTION
- Add string formatter that does string interpolation. For "blah {key} blah", yield "blah blah blah" if context key=blah.
- Shell and Safeshell uses string interpolator.
- Readme updates to describe new functionality.