### PR TITLE
Assert validator signature changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ pypyr cli pipeline runner
 pypyr is a command line interface to run pipelines defined in yaml. Think of
 pypyr as a simple task runner that lets you run sequential steps.
 
-|build-status| |coverage|
+|build-status| |coverage| |pypi|
 
 .. contents::
 
@@ -722,3 +722,8 @@ https://www.345.systems/contact.
 .. |coverage| image:: https://api.shippable.com/projects/58efdfe130eb380700e559a6/coverageBadge?branch=master
                 :alt: coverage status
                 :target: https://app.shippable.com/github/pypyr/pypyr-cli
+
+.. |pypi| image:: https://badge.fury.io/py/pypyr.svg
+                :alt: pypi version
+                :target: https://pypi.python.org/pypi/pypyr/
+                :align: bottom

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -38,17 +38,17 @@ class Context(dict):
         assert self[key], (
             f"context['{key}'] must have a value for {caller}.")
 
-    def asserts_keys_have_values(self, keys, caller):
+    def assert_keys_have_values(self, caller, *keys):
         """Check that keys list are all in context and all have values.
 
         Args:
-            keys: list. Will check each of these keys in context
+            *keys: Will check each of these keys in context
             caller: string. Calling function name - just used for informational
                     messages
 
         Raises:
-            AssertionError: if dictionary is None, key doesn't exist in
-                            dictionary, or dictionary[key] is None.
+            AssertionError: if context is None, key doesn't exist in
+                            context, or context[key] is None.
         """
         for key in keys:
             self.assert_key_has_value(key, caller)

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -111,7 +111,7 @@ def test_assert_key_has_value_passes():
 def test_assert_keys_have_values_passes():
     """Pass if list of keys all found in context dictionary."""
     context = Context({'key1': 'value1', 'key2': 'value2', 'key3': 'value3'})
-    context.asserts_keys_have_values(['key1', 'key3'], None)
+    context.assert_keys_have_values(None, 'key1', 'key3')
 
 
 def test_assert_keys_have_values_fails():
@@ -120,10 +120,11 @@ def test_assert_keys_have_values_fails():
         context = Context({'key1': 'value1',
                            'key2': 'value2',
                            'key3': 'value3'})
-        context.asserts_keys_have_values(['key1',
-                                          'key4',
-                                          'key2'],
-                                         None)
+        context.assert_keys_have_values(None,
+                                        'key1',
+                                        'key4',
+                                        'key2',
+                                        )
 
 # ------------------- asserts ------------------------------------------------#
 


### PR DESCRIPTION
-  `asserts_keys_have_values(self, keys, caller)` is now `assert_keys_have_values(self, caller, *keys)`
- add pypi version badge to readme