### PR TITLE
Breaking change: What's my --name?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,14 +43,14 @@ Run one of the built-in pipelines to get a feel for it:
 
 .. code-block:: bash
 
-  $ pypyr --name echo --context "echoMe=Ceci n'est pas une pipe" --log 20
+  $ pypyr --name echo --context "echoMe=Ceci n'est pas une pipe"
 
 You can achieve the same thing by running a pipeline where the context is set
 in the pipeline yaml rather than as a --context argument:
 
 .. code-block:: bash
 
-  $ pypyr --name magritte --log 20
+  $ pypyr --name magritte
 
 Check here `pypyr.steps.echo`_ to see yaml that does this.
 
@@ -61,10 +61,13 @@ pypyr assumes a pipelines directory in your current working directory.
 .. code-block:: bash
 
   # run pipelines/mypipelinename.yaml with DEBUG logging level
-  $ pypyr --name mypipelinename
+  $ pypyr --name mypipelinename --log 10
 
-  # run pipelines/mypipelinename.yaml with INFO logging level
+  # run pipelines/mypipelinename.yaml with INFO logging level.
   $ pypyr --name mypipelinename --log 20
+
+  # If you don't specify --log it defaults to 20 - INFO logging level.
+  $ pypyr --name mypipelinename
 
   # run pipelines/mypipelinename.yaml with an input context. For this input to
   # be available to your pipeline you need to specify a context_parser in your
@@ -131,13 +134,13 @@ Built-in pipelines
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| echo                        | Echos context value echoMe to output.           |`pypyr --name echo --context "echoMe=text goes here" --log 20`                       |
+| echo                        | Echos context value echoMe to output.           |`pypyr --name echo --context "echoMe=text goes here"`                       |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyrversion                | Prints the python cli version number.           |`pypyr --name pypyrversion --log 20`                                                 |
+| pypyrversion                | Prints the python cli version number.           |`pypyr --name pypyrversion`                                                 |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| magritte                    | Thoughts about pipes.                           |`pypyr --name magritte --log 20`                                                     |
+| magritte                    | Thoughts about pipes.                           |`pypyr --name magritte`                                                     |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
@@ -367,7 +370,7 @@ You can run:
 
 .. code-block:: bash
 
-  $ pypyr --name look-ma-no-params --log 20
+  $ pypyr --name look-ma-no-params
 
 pypyr.steps.env
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -134,13 +134,13 @@ Built-in pipelines
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| echo                        | Echos context value echoMe to output.           |`pypyr --name echo --context "echoMe=text goes here"`                       |
+| echo                        | Echos context value echoMe to output.           |`pypyr --name echo --context "echoMe=text goes here"`                                |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyrversion                | Prints the python cli version number.           |`pypyr --name pypyrversion`                                                 |
+| pypyrversion                | Prints the python cli version number.           |`pypyr --name pypyrversion`                                                          |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| magritte                    | Thoughts about pipes.                           |`pypyr --name magritte`                                                     |
+| magritte                    | Thoughts about pipes.                           |`pypyr --name magritte`                                                              |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+

--- a/README.rst
+++ b/README.rst
@@ -43,14 +43,14 @@ Run one of the built-in pipelines to get a feel for it:
 
 .. code-block:: bash
 
-  $ pypyr --name echo --context "echoMe=Ceci n'est pas une pipe"
+  $ pypyr echo --context "echoMe=Ceci n'est pas une pipe"
 
 You can achieve the same thing by running a pipeline where the context is set
 in the pipeline yaml rather than as a --context argument:
 
 .. code-block:: bash
 
-  $ pypyr --name magritte
+  $ pypyr magritte
 
 Check here `pypyr.steps.echo`_ to see yaml that does this.
 
@@ -61,18 +61,18 @@ pypyr assumes a pipelines directory in your current working directory.
 .. code-block:: bash
 
   # run pipelines/mypipelinename.yaml with DEBUG logging level
-  $ pypyr --name mypipelinename --log 10
+  $ pypyr mypipelinename --log 10
 
   # run pipelines/mypipelinename.yaml with INFO logging level.
-  $ pypyr --name mypipelinename --log 20
+  $ pypyr mypipelinename --log 20
 
   # If you don't specify --log it defaults to 20 - INFO logging level.
-  $ pypyr --name mypipelinename
+  $ pypyr mypipelinename
 
   # run pipelines/mypipelinename.yaml with an input context. For this input to
   # be available to your pipeline you need to specify a context_parser in your
   # pipeline yaml.
-  $ pypyr --name mypipelinename --context 'mykey=value'
+  $ pypyr mypipelinename --context 'mykey=value'
 
 Get cli help
 ============
@@ -99,7 +99,7 @@ working directory.
 
   # This is an example showing the anatomy of a pypyr pipeline
   # A pipeline should be saved as {working dir}/pipelines/mypipelinename.yaml.
-  # Run the pipeline from {working dir} like this: pypyr --name mypipelinename
+  # Run the pipeline from {working dir} like this: pypyr mypipelinename
 
   # optional
   context_parser: my.custom.parser
@@ -129,18 +129,18 @@ Built-in pipelines
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | **pipeline**                | **description**                                 | **how to run**                                                                      |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| donothing                   | Does what it says. Nothing.                     |`pypyr --name donothing`                                                             |
+| donothing                   | Does what it says. Nothing.                     |`pypyr donothing`                                                                    |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| echo                        | Echos context value echoMe to output.           |`pypyr --name echo --context "echoMe=text goes here"`                                |
+| echo                        | Echos context value echoMe to output.           |`pypyr echo --context "echoMe=text goes here"`                                       |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyrversion                | Prints the python cli version number.           |`pypyr --name pypyrversion`                                                          |
+| pypyrversion                | Prints the python cli version number.           |`pypyr pypyrversion`                                                                 |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| magritte                    | Thoughts about pipes.                           |`pypyr --name magritte`                                                              |
+| magritte                    | Thoughts about pipes.                           |`pypyr magritte`                                                                     |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
@@ -162,7 +162,7 @@ Built-in context parsers
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | **context parser**          | **description**                                 | **example input**                                                                   |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.commas         | Takes a comma delimited string and returns a    |`pypyr --name pipelinename --context "param1,param2,param3"`                         |
+| pypyr.parser.commas         | Takes a comma delimited string and returns a    |`pypyr pipelinename --context "param1,param2,param3"`                                |
 |                             | dictionary where each element becomes the key,  |                                                                                     |
 |                             | with value to true.                             |This will create a context dictionary like this:                                     |
 |                             |                                                 |{'param1': True, 'param2': True, 'param3': True}                                     |
@@ -170,11 +170,11 @@ Built-in context parsers
 |                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
 |                             | a context key name of \' k2\' not \'k2\'.       |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.json           | Takes a json string and returns a dictionary.   |`pypyr --name pipelinename --context \'{"key1":"value1","key2":"value2"}\'`          |
+| pypyr.parser.json           | Takes a json string and returns a dictionary.   |`pypyr pipelinename --context \'{"key1":"value1","key2":"value2"}\'`                 |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.jsonfile       | Opens json file and returns a dictionary.       |`pypyr --name pipelinename --context \'./path/sample.json'`                          |
+| pypyr.parser.jsonfile       | Opens json file and returns a dictionary.       |`pypyr pipelinename --context \'./path/sample.json'`                                 |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.keyvaluepairs  | Takes a comma delimited key=value pair string   |`pypyr --name pipelinename --context "param1=value1,param2=value2,param3=value3"`    |
+| pypyr.parser.keyvaluepairs  | Takes a comma delimited key=value pair string   |`pypyr pipelinename --context "param1=value1,param2=value2,param3=value3"`           |
 |                             | and returns a dictionary where each pair becomes|                                                                                     |
 |                             | a dictionary element.                           |                                                                                     |
 |                             |                                                 |                                                                                     |
@@ -182,7 +182,7 @@ Built-in context parsers
 |                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
 |                             | a context key name of \' k2\' not \'k2\'.       |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.yamlfile       | Opens a yaml file and writes the contents into  |`pypyr --name pipelinename --context \'./path/sample.yaml'`                          |
+| pypyr.parser.yamlfile       | Opens a yaml file and writes the contents into  |`pypyr pipelinename --context \'./path/sample.yaml'`                                 |
 |                             | the pypyr context dictionary.                   |                                                                                     |
 |                             |                                                 |                                                                                     |
 |                             | The top (or root) level yaml should describe a  |                                                                                     |
@@ -352,7 +352,7 @@ You can run:
 
 .. code-block:: bash
 
-  pypyr --name mypipeline --context "echoMe=Ceci n'est pas une pipe"
+  pypyr mypipeline --context "echoMe=Ceci n'est pas une pipe"
 
 
 Alternatively, if you had pipelines/look-ma-no-params.yaml like this:
@@ -370,7 +370,7 @@ You can run:
 
 .. code-block:: bash
 
-  $ pypyr --name look-ma-no-params
+  $ pypyr look-ma-no-params
 
 pypyr.steps.env
 ^^^^^^^^^^^^^^^

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import pypyr.pipelinerunner
 import pypyr.version
+import sys
 
 
 def get_args():
@@ -33,9 +34,27 @@ def get_args():
 
 
 def main():
+    """Entry point for pypyr cli.
+
+    The setup_py entry_point wraps this in sys.exit already so this effectively
+    becomes sys.exit(main()).
+    The __main__ entry point similarly wraps sys.exit().
+    """
     args = get_args()
-    return pypyr.pipelinerunner.main(
-        pipeline_name=args.pipeline_name,
-        pipeline_context_input=args.pipeline_context,
-        working_dir=args.working_dir,
-        log_level=args.log_level)
+
+    try:
+        return pypyr.pipelinerunner.main(
+            pipeline_name=args.pipeline_name,
+            pipeline_context_input=args.pipeline_context,
+            working_dir=args.working_dir,
+            log_level=args.log_level)
+    except KeyboardInterrupt:
+        # Shell standard is 128 + signum = 130 (SIGINT = 2)
+        sys.stdout.write("\n")
+        return 128 + signal.SIGINT
+    except Exception as e:
+        # stderr and exit code 255
+        sys.stderr.write("\n")
+        sys.stderr.write(f"{type(e).__name__}: {str(e)}")
+        sys.stderr.write("\n")
+        return 255

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -10,7 +10,7 @@ import signal
 import sys
 
 
-def get_args():
+def get_args(args):
     """Parse arguments passed in from shell."""
     parser = argparse.ArgumentParser(
         allow_abbrev=True,
@@ -31,24 +31,27 @@ def get_args():
                         help='Echo version number.',
                         version=f'{pypyr.version.get_version()}')
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
-def main():
+def main(args=None):
     """Entry point for pypyr cli.
 
     The setup_py entry_point wraps this in sys.exit already so this effectively
     becomes sys.exit(main()).
     The __main__ entry point similarly wraps sys.exit().
     """
-    args = get_args()
+    if args is None:
+        args = sys.argv[1:]
+
+    parsed_args = get_args(args)
 
     try:
         return pypyr.pipelinerunner.main(
-            pipeline_name=args.pipeline_name,
-            pipeline_context_input=args.pipeline_context,
-            working_dir=args.working_dir,
-            log_level=args.log_level)
+            pipeline_name=parsed_args.pipeline_name,
+            pipeline_context_input=parsed_args.pipeline_context,
+            working_dir=parsed_args.working_dir,
+            log_level=parsed_args.log_level)
     except KeyboardInterrupt:
         # Shell standard is 128 + signum = 130 (SIGINT = 2)
         sys.stdout.write("\n")

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -22,10 +22,10 @@ def get_parser():
         description='pypyr pipeline runner')
     parser.add_argument('pipeline_name',
                         help='Name of pipeline to run. It should exist in the '
-                        '/pipelines directory.')
+                        './pipelines directory.')
     parser.add_argument('--context', dest='pipeline_context',
-                        help='String for context values. Parsed by '
-                        'pipeline''s context_parser function.')
+                        help='String for context values. Parsed by the '
+                        'pipeline\'s context_parser function.')
     parser.add_argument('--dir', dest='working_dir', default=os.getcwd(),
                         help='Working directory. Use if your pipelines '
                         'directory is elsewhere. Defaults to cwd.')

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import pypyr.pipelinerunner
 import pypyr.version
+import signal
 import sys
 
 
@@ -55,6 +56,6 @@ def main():
     except Exception as e:
         # stderr and exit code 255
         sys.stderr.write("\n")
-        sys.stderr.write(f"{type(e).__name__}: {str(e)}")
+        sys.stderr.write(f"\033[91m{type(e).__name__}: {str(e)}")
         sys.stderr.write("\n")
         return 255

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -23,7 +23,7 @@ def get_args():
     parser.add_argument('--dir', dest='working_dir', default=os.getcwd(),
                         help='Working directory. Use if your pipelines '
                         'directory is elsewhere. Defaults to cwd.')
-    parser.add_argument('--loglevel', dest='log_level', type=int, default=10,
+    parser.add_argument('--loglevel', dest='log_level', type=int, default=20,
                         help='Integer log level. Defaults to 10 (Debug). '
                         '10=DEBUG 20=INFO 30=WARNING 40=ERROR 50=CRITICAL')
     parser.add_argument('--version', action='version',

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -20,7 +20,7 @@ def get_parser():
     parser = argparse.ArgumentParser(
         allow_abbrev=True,
         description='pypyr pipeline runner')
-    parser.add_argument('--name', dest='pipeline_name', required=True,
+    parser.add_argument('pipeline_name',
                         help='Name of pipeline to run. It should exist in the '
                         '/pipelines directory.')
     parser.add_argument('--context', dest='pipeline_context',

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -12,6 +12,11 @@ import sys
 
 def get_args(args):
     """Parse arguments passed in from shell."""
+    return get_parser().parse_args(args)
+
+
+def get_parser():
+    """Return ArgumentParser for pypyr cli."""
     parser = argparse.ArgumentParser(
         allow_abbrev=True,
         description='pypyr pipeline runner')
@@ -30,8 +35,7 @@ def get_args(args):
     parser.add_argument('--version', action='version',
                         help='Echo version number.',
                         version=f'{pypyr.version.get_version()}')
-
-    return parser.parse_args(args)
+    return parser
 
 
 def main(args=None):

--- a/pypyr/pipelines/donothing.yaml
+++ b/pypyr/pipelines/donothing.yaml
@@ -1,3 +1,3 @@
 # To execute this pipeline, shell something like:
-# pypyr --name donothing
+# pypyr donothing
 steps:

--- a/pypyr/pipelines/echo.yaml
+++ b/pypyr/pipelines/echo.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, shell something like:
-# pypyr --name echo --context "echoMe=text goes here"
+# pypyr echo --context "echoMe=text goes here"
 context_parser: pypyr.parser.keyvaluepairs
 steps:
   - pypyr.steps.echo

--- a/pypyr/pipelines/magritte.yaml
+++ b/pypyr/pipelines/magritte.yaml
@@ -1,5 +1,7 @@
-  steps:
-    - name: pypyr.steps.echo
-      description: Output echoMe
-      in:
-        echoMe: Ceci n'est pas une pipe
+# To execute this pipeline, shell something like:
+# pypyr magritte
+steps:
+  - name: pypyr.steps.echo
+    description: Output echoMe
+    in:
+      echoMe: Ceci n'est pas une pipe

--- a/pypyr/pipelines/pypyrversion.yaml
+++ b/pypyr/pipelines/pypyrversion.yaml
@@ -1,4 +1,4 @@
 # To execute this pipeline, shell something like:
-# pypyr --name pypyrversion
+# pypyr pypyrversion
 steps:
   - pypyr.steps.pypyrversion

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.3.2'
+__version__ = '0.4.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,11 @@ current_version = 0.3.2
 [bdist_wheel]
 universal = 0
 
+[coverage:report]
+exclude_lines =
+	pragma: no cover
+	if 0:
+	if __name__ == .__main__.:
+  
 [coverage:run]
 branch = True
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,15 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.4.0
 
 [bdist_wheel]
 universal = 0
 
 [coverage:report]
-exclude_lines =
+exclude_lines = 
 	pragma: no cover
 	if 0:
 	if __name__ == .__main__.:
-  
+
 [coverage:run]
 branch = True
+

--- a/tests/unit/pypyr/__main__test.py
+++ b/tests/unit/pypyr/__main__test.py
@@ -1,0 +1,11 @@
+"""__main__.py unit tests."""
+import pypyr.__main__
+from unittest.mock import patch
+
+
+def test_main_calls_main():
+    """The python -m entry point should call pypyr.cli.main()"""
+    with patch('pypyr.cli.main') as mock_cli_main:
+        pypyr.__main__.main()
+
+    mock_cli_main.assert_called_once()

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -1,0 +1,82 @@
+"""cli.py unit tests."""
+import os
+import pypyr.cli
+import pytest
+from unittest.mock import patch
+
+
+def test_main_pass_with_sysargv():
+    """Invoke from cli sets sys.argv, check assigns correctly to args."""
+    arg_list = ['pypyr',
+                'blah',
+                '--log',
+                '50',
+                '--context',
+                'ctx string',
+                '--dir',
+                'dir here']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            pypyr.cli.main()
+
+        mock_pipeline_main.assert_called_once_with(
+            pipeline_name='blah',
+            pipeline_context_input='ctx string',
+            working_dir='dir here',
+            log_level=50
+        )
+
+
+def test_main_pass_with_defaults():
+    """Default values assigned - log 20 and cwd"""
+    arg_list = ['blah',
+                '--context',
+                'ctx string']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        pypyr.cli.main(arg_list)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input='ctx string',
+        working_dir=os.getcwd(),
+        log_level=20
+    )
+
+
+def test_pipeline_name_required():
+    """Error expected if no pipeline name"""
+    arg_list = ['--context',
+                'ctx string']
+
+    with patch('pypyr.pipelinerunner.main'):
+        with pytest.raises(SystemExit) as exit_err:
+            pypyr.cli.main(arg_list)
+
+        print(exit_err.value)
+        assert exit_err.value.code == 2
+
+
+def test_interrupt_signal():
+    """Interrupt signal handled."""
+    arg_list = ['blah',
+                '--context',
+                'ctx string']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        mock_pipeline_main.side_effect = KeyboardInterrupt()
+        val = pypyr.cli.main(arg_list)
+        assert val == 130
+
+
+def test_arb_error():
+    """Arbitrary error should return 255."""
+    arg_list = ['blah',
+                '--context',
+                'ctx string']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        mock_pipeline_main.side_effect = AssertionError('Test Error Mock')
+        val = pypyr.cli.main(arg_list)
+        assert val == 255


### PR DESCRIPTION
- the cli now takes --name as default. instead of `pypyr --name mypipe` it's `pypyr mypipe`
- log level defaults to INFO
- signal interrupt handled (ctrl + c)
- stderr output red