### PR TITLE
EnvSet uses formatstrings and TRACE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -426,26 +426,29 @@ Set $ENVs from the pypyr context.
 
 ``context['envSet']`` must exist. It's a dictionary.
 
-Values are the keys of the pypyr context values to write to $ENV.
+Values are strings to write to $ENV. You can use {key} substitutions to format
+the string from context.
 Keys are the names of the $ENV values to which to write.
 
 For example, say input context is:
 
 .. code-block:: yaml
 
-    key1: value1
-    key2: value2
-    key3: value3
-    envSet:
-        MYVAR1: key1
-        MYVAR2: key3
+  key1: value1
+  key2: value2
+  key3: value3
+  envSet:
+      MYVAR1: {key1}
+      MYVAR2: before_{key3}_after
+      MYVAR3: arbtexthere
 
 This will result in the following $ENVs:
 
 .. code-block:: yaml
 
   $MYVAR1 = value1
-  $MYVAR2 = value3
+  $MYVAR2 = before_value3_after
+  $MYVAR3 = arbtexthere
 
 Note that the $ENVs are not persisted system-wide, they only exist for the
 pypyr sub-processes, and as such for the subsequent steps during this pypyr

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -8,6 +8,7 @@ import pypyr.pipelinerunner
 import pypyr.version
 import signal
 import sys
+import traceback
 
 
 def get_args(args):
@@ -30,8 +31,9 @@ def get_parser():
                         help='Working directory. Use if your pipelines '
                         'directory is elsewhere. Defaults to cwd.')
     parser.add_argument('--loglevel', dest='log_level', type=int, default=20,
-                        help='Integer log level. Defaults to 10 (Debug). '
-                        '10=DEBUG 20=INFO 30=WARNING 40=ERROR 50=CRITICAL')
+                        help='Integer log level. Defaults to 20 (INFO). '
+                        '10=DEBUG\n20=INFO\n30=WARNING\n40=ERROR\n50=CRITICAL'
+                        '.\n Log Level < 10 gives full traceback on errors.')
     parser.add_argument('--version', action='version',
                         help='Echo version number.',
                         version=f'{pypyr.version.get_version()}')
@@ -65,4 +67,9 @@ def main(args=None):
         sys.stderr.write("\n")
         sys.stderr.write(f"\033[91m{type(e).__name__}: {str(e)}\033[0;0m")
         sys.stderr.write("\n")
+        # at this point, you're guaranteed to have args and thus log_level
+        if parsed_args.log_level < 10:
+            # traceback prints to stderr by default
+            traceback.print_exc()
+
         return 255

--- a/pypyr/steps/env.py
+++ b/pypyr/steps/env.py
@@ -80,25 +80,27 @@ def env_get(context):
 
 
 def env_set(context):
-    """Set $ENVs from the pypyr context.
+    """Set $ENVs to specified string. from the pypyr context.
 
-    Context is a dictionary or dictionary-like. context is mandatory.
-
-    context['envSet'] must exist. It's a dictionary.
-    Values are the keys of the pypyr context values to write to $ENV.
-    Keys are the names of the $ENV values to which to write.
+    Args:
+        context: is dictionary-like. context is mandatory.
+                 context['envSet'] must exist. It's a dictionary.
+                 Values are strings to write to $ENV.
+                 Keys are the names of the $ENV values to which to write.
 
     For example, say input context is:
         key1: value1
         key2: value2
         key3: value3
         envSet:
-            MYVAR1: key1
-            MYVAR2: key3
+            MYVAR1: {key1}
+            MYVAR2: before_{key3}_after
+            MYVAR3: arbtexthere
 
     This will result in the following $ENVs:
     $MYVAR1 = value1
-    $MYVAR2 = value3
+    $MYVAR2 = before_value3_after
+    $MYVAR3 = arbtexthere
 
     Note that the $ENVs are not persisted system-wide, they only exist for
     pypyr sub-processes, and as such for the following steps during this pypyr
@@ -109,7 +111,7 @@ def env_set(context):
 
     for k, v in context['envSet'].items():
         logger.debug(f"setting ${k} to context[{v}]")
-        os.environ[k] = context[v]
+        os.environ[k] = context.get_formatted_string(v)
 
     logger.debug("done")
 

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.5.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -80,3 +80,20 @@ def test_arb_error():
         mock_pipeline_main.side_effect = AssertionError('Test Error Mock')
         val = pypyr.cli.main(arg_list)
         assert val == 255
+
+
+def test_trace_log_level():
+    """Log Level < 10 produces traceback on error."""
+    arg_list = ['blah',
+                '--context',
+                'ctx string',
+                '--log',
+                '5']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        with patch('traceback.print_exc') as mock_traceback:
+            mock_pipeline_main.side_effect = AssertionError('Test Error Mock')
+            val = pypyr.cli.main(arg_list)
+            assert val == 255
+
+    mock_traceback.assert_called_once()


### PR DESCRIPTION
- envSet from pypyr.steps.env uses format strings. Breaking change - previously these took values directly from context based on key.
- add TRACE level logging for full traceback