### PR TITLE
Steps: tar, contextclear, contextclearall. Errs: KeyNotInContext, KeyInContextHasNoValue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -656,15 +656,15 @@ You can use {key} substitutions to format the string from context.
 .. code-block:: yaml
 
   key1: here
-  key2: tar.xs
+  key2: tar.xz
   tarExtract:
-    path/to/my.tar.xs: /path/extract/{key1}
+    path/to/my.tar.xz: /path/extract/{key1}
     another/{key2}: .
 
 This will:
 
-- Extract *path/to/my.tar.xs* to */path/extract/here*
-- Extract *another/tar.xs* to the current execution directory
+- Extract *path/to/my.tar.xz* to */path/extract/here*
+- Extract *another/tar.xz* to the current execution directory
 
   - This is the directory you're running pypyr from, not the pypyr pipeline
     working directory you set with the ``--dir`` flag.
@@ -681,16 +681,16 @@ You can use {key} substitutions to format the string from context.
 
 .. code-block:: yaml
 
-  key1: destination.tar.xs
+  key1: destination.tar.xz
   key2: value2
   tarArchive:
     path/{key2}/dir: path/to/{key1}
-    another/my.file: ./my.tar.xs
+    another/my.file: ./my.tar.xz
 
 This will:
 
-- Archive directory *path/value2/dir* to *path/to/destination.tar.xs*,
-- Archive file *another/my.file* to *./my.tar.xs*
+- Archive directory *path/value2/dir* to *path/to/destination.tar.xz*,
+- Archive file *another/my.file* to *./my.tar.xz*
 
 
 Roll your own step

--- a/README.rst
+++ b/README.rst
@@ -674,8 +674,10 @@ You can use {key} substitutions to format the string from context.
   key1: here
   key2: tar.xz
   tarExtract:
-    path/to/my.tar.xz: /path/extract/{key1}
-    another/{key2}: .
+    - in: path/to/my.tar.xz
+      out: /path/extract/{key1}
+    - in: another/{key2}
+      out: .
 
 This will:
 
@@ -700,8 +702,10 @@ You can use {key} substitutions to format the string from context.
   key1: destination.tar.xz
   key2: value2
   tarArchive:
-    path/{key2}/dir: path/to/{key1}
-    another/my.file: ./my.tar.xz
+    - in: path/{key2}/dir
+      out: path/to/{key1}
+    - in: another/my.file
+      out: ./my.tar.xz
 
 This will:
 

--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,9 @@ Built-in steps
 +-----------------------------+-------------------------------------------------+------------------------------+
 | **step**                    | **description**                                 | **input context properties** |
 +-----------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.contextclear`_ | Remove specified items from context.            | contextClear (list)          |
+|                             |                                                 |                              |
++-----------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.contextset`_   | Sets context values from already existing       | contextSet (dict)            |
 |                             | context values.                                 |                              |
 +-----------------------------+-------------------------------------------------+------------------------------+
@@ -300,6 +303,34 @@ Built-in steps
 |                             | compression. Supports gzip, bzip2, lzma.        |                              |
 |                             |                                                 | tarArchive (dict)            |
 +-----------------------------+-------------------------------------------------+------------------------------+
+
+pypyr.steps.contextclear
+^^^^^^^^^^^^^^^^^^^^^^^^
+Remove the specified items from the context.
+
+Will iterate ``contextClear`` and remove those keys from context.
+
+For example, say input context is:
+
+.. code-block:: yaml
+
+      key1: value1
+      key2: value2
+      key3: value3
+      key4: value4
+      contextClear:
+          - key2
+          - key4
+          - contextClear
+
+This will result in return context:
+
+.. code-block:: yaml
+
+      key1: value1
+      key3: value3
+
+Notice how contextClear also cleared itself in this example.
 
 pypyr.steps.contextset
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -634,7 +665,9 @@ This will:
 
 - Extract *path/to/my.tar.xs* to */path/extract/here*
 - Extract *another/tar.xs* to the current execution directory
-  - This is the directory you're running pypyr from, not the pypyr pipeline working directory you set with the ``--dir`` flag.
+
+  - This is the directory you're running pypyr from, not the pypyr pipeline
+    working directory you set with the ``--dir`` flag.
 
 tarArchive
 """"""""""

--- a/README.rst
+++ b/README.rst
@@ -274,14 +274,14 @@ Built-in steps
 +-----------------------------+-------------------------------------------------+------------------------------+
 | **step**                    | **description**                                 | **input context properties** |
 +-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.contextset`_   | Sets context values from already existing       | contextSet (dictionary)      |
+| `pypyr.steps.contextset`_   | Sets context values from already existing       | contextSet (dict)            |
 |                             | context values.                                 |                              |
 +-----------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.echo`_         | Echo the context value `echoMe` to the output.  | echoMe (string)              |
 +-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.env`_          | Get, set or unset $ENVs.                        | envGet (dictionary)          |
+| `pypyr.steps.env`_          | Get, set or unset $ENVs.                        | envGet (dict)                |
 |                             |                                                 |                              |
-|                             |                                                 | envSet (dictionary)          |
+|                             |                                                 | envSet (dict)                |
 |                             |                                                 |                              |
 |                             |                                                 | envUnset (list)              |
 +-----------------------------+-------------------------------------------------+------------------------------+
@@ -295,6 +295,10 @@ Built-in steps
 +-----------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.shell`_        | Runs the context value `cmd` in the default     | cmd (string)                 |
 |                             | shell. Use for pipes, wildcards, $ENVs, ~       |                              |
++-----------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.tar`_          | Archive and/or extract tars with or without     | tarExtract (dict)            |
+|                             | compression. Supports gzip, bzip2, lzma.        |                              |
+|                             |                                                 | tarArchive (dict)            |
 +-----------------------------+-------------------------------------------------+------------------------------+
 
 pypyr.steps.contextset
@@ -579,6 +583,82 @@ Example pipeline yaml using a pipe:
 
 See a worked example `for shell power here
 <https://github.com/pypyr/pypyr-example/tree/master/pipelines/shell.yaml>`__.
+
+pypyr.steps.tar
+^^^^^^^^^^^^^^^
+Archive and/or extract tars with or without compression.
+
+At least one of these context keys must exist:
+
+- tarExtract
+- tarArchive
+
+Optionally, you can also specify the tar compression format with
+``context['tarFormat']``. If not specified, defaults to *lzma/xz*
+Available options:
+
+- '' - no compression
+- gz (gzip)
+- bz2 (bzip2)
+- xz (lzma)
+
+This step will run whatever combination of Extract and Archive you specify.
+Regardless of combination, execution order is Extract, Archive.
+
+Never extract archives from untrusted sources without prior inspection. It is
+possible that files are created outside of path, e.g. members that have
+absolute filenames starting with "/" or filenames with two dots "..".
+
+See a worked example `for tar here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/tar.yaml>`__.
+
+tarExtract
+""""""""""
+``context['tarExtract']`` must exist. It's a dictionary.
+
+keys are the path to the tar to extract.
+
+values are the destination paths.
+
+You can use {key} substitutions to format the string from context.
+
+.. code-block:: yaml
+
+  key1: here
+  key2: tar.xs
+  tarExtract:
+    path/to/my.tar.xs: /path/extract/{key1}
+    another/{key2}: .
+
+This will:
+
+- Extract *path/to/my.tar.xs* to */path/extract/here*
+- Extract *another/tar.xs* to the current execution directory
+  - This is the directory you're running pypyr from, not the pypyr pipeline working directory you set with the ``--dir`` flag.
+
+tarArchive
+""""""""""
+``context['tarArchive']`` must exist. It's a dictionary.
+
+keys are the paths to archive.
+
+values are the destination output paths.
+
+You can use {key} substitutions to format the string from context.
+
+.. code-block:: yaml
+
+  key1: destination.tar.xs
+  key2: value2
+  tarArchive:
+    path/{key2}/dir: path/to/{key1}
+    another/my.file: ./my.tar.xs
+
+This will:
+
+- Archive directory *path/value2/dir* to *path/to/destination.tar.xs*,
+- Archive file *another/my.file* to *./my.tar.xs*
+
 
 Roll your own step
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -271,38 +271,40 @@ You can specify a step in the pipeline yaml in two ways:
 Built-in steps
 --------------
 
-+-----------------------------+-------------------------------------------------+------------------------------+
-| **step**                    | **description**                                 | **input context properties** |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.contextclear`_ | Remove specified items from context.            | contextClear (list)          |
-|                             |                                                 |                              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.contextset`_   | Sets context values from already existing       | contextSet (dict)            |
-|                             | context values.                                 |                              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.echo`_         | Echo the context value `echoMe` to the output.  | echoMe (string)              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.env`_          | Get, set or unset $ENVs.                        | envGet (dict)                |
-|                             |                                                 |                              |
-|                             |                                                 | envSet (dict)                |
-|                             |                                                 |                              |
-|                             |                                                 | envUnset (list)              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.py`_           | Executes the context value `pycode` as python   | pycode (string)              |
-|                             | code.                                           |                              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.pypyrversion`_ | Writes installed pypyr version to output.       |                              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.safeshell`_    | Runs the program and args specified in the      | cmd (string)                 |
-|                             | context value `cmd` as a subprocess.            |                              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.shell`_        | Runs the context value `cmd` in the default     | cmd (string)                 |
-|                             | shell. Use for pipes, wildcards, $ENVs, ~       |                              |
-+-----------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.tar`_          | Archive and/or extract tars with or without     | tarExtract (dict)            |
-|                             | compression. Supports gzip, bzip2, lzma.        |                              |
-|                             |                                                 | tarArchive (dict)            |
-+-----------------------------+-------------------------------------------------+------------------------------+
++-------------------------------+-------------------------------------------------+------------------------------+
+| **step**                      | **description**                                 | **input context properties** |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.contextclear`_   | Remove specified items from context.            | contextClear (list)          |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.contextclearall`_| Wipe the entire context.                        |                              |
+|                               |                                                 |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.contextset`_     | Sets context values from already existing       | contextSet (dict)            |
+|                               | context values.                                 |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.echo`_           | Echo the context value `echoMe` to the output.  | echoMe (string)              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.env`_            | Get, set or unset $ENVs.                        | envGet (dict)                |
+|                               |                                                 |                              |
+|                               |                                                 | envSet (dict)                |
+|                               |                                                 |                              |
+|                               |                                                 | envUnset (list)              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.py`_             | Executes the context value `pycode` as python   | pycode (string)              |
+|                               | code.                                           |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.pypyrversion`_   | Writes installed pypyr version to output.       |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.safeshell`_      | Runs the program and args specified in the      | cmd (string)                 |
+|                               | context value `cmd` as a subprocess.            |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.shell`_          | Runs the context value `cmd` in the default     | cmd (string)                 |
+|                               | shell. Use for pipes, wildcards, $ENVs, ~       |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.tar`_            | Archive and/or extract tars with or without     | tarExtract (dict)            |
+|                               | compression. Supports gzip, bzip2, lzma.        |                              |
+|                               |                                                 | tarArchive (dict)            |
++-------------------------------+-------------------------------------------------+------------------------------+
 
 pypyr.steps.contextclear
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -314,23 +316,37 @@ For example, say input context is:
 
 .. code-block:: yaml
 
-      key1: value1
-      key2: value2
-      key3: value3
-      key4: value4
-      contextClear:
-          - key2
-          - key4
-          - contextClear
+    key1: value1
+    key2: value2
+    key3: value3
+    key4: value4
+    contextClear:
+        - key2
+        - key4
+        - contextClear
 
 This will result in return context:
 
 .. code-block:: yaml
 
-      key1: value1
-      key3: value3
+    key1: value1
+    key3: value3
 
 Notice how contextClear also cleared itself in this example.
+
+pypyr.steps.contextclearall
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Wipe the entire context. No input context arguments required.
+
+You can always use *contextclearall* as a simple step. Sample pipeline yaml:
+
+.. code-block:: yaml
+
+    steps:
+      - my.arb.step
+      - pypyr.steps.contextclearall
+      - another.arb.step
+
 
 pypyr.steps.contextset
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -200,8 +200,8 @@ class Context(dict):
                     f'context[\'{missing_key}\'] doesn\'t exist'
                 ) from err
         else:
-            raise TypeError("can only format on strings. {val} is a "
-                            "{type(val)} instead.")
+            raise TypeError(f"can only format on strings. {val} is a "
+                            f"{type(val)} instead.")
 
     def get_formatted_string(self, input_string):
         """Returns formatted value for input_string.
@@ -241,8 +241,8 @@ class Context(dict):
                     f'{{{missing_key}}}, because '
                     f'context[\'{missing_key}\'] doesn\'t exist') from err
         else:
-            raise TypeError("can only format on strings. {input_string} is a "
-                            "{type(input_string)} instead.")
+            raise TypeError(f"can only format on strings. {input_string} is a "
+                            f"{type(input_string)} instead.")
 
     def keys_exist(self, *keys):
         """Check if keys exist in context.

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -35,7 +35,7 @@ class Context(dict):
         assert key in self, (
             f"context['{key}'] doesn't exist. It must have a value for "
             f"{caller}.")
-        assert self[key], (
+        assert self[key] is not None, (
             f"context['{key}'] must have a value for {caller}.")
 
     def assert_keys_have_values(self, caller, *keys):

--- a/pypyr/errors.py
+++ b/pypyr/errors.py
@@ -8,11 +8,15 @@ class Error(Exception):
     """Base class for all pypyr exceptions."""
 
 
-class KeyInContextHasNoValueError(Error):
+class ContextError(Error):
+    """Error in the pypyr context."""
+
+
+class KeyInContextHasNoValueError(ContextError):
     """pypyr context[key] doesn't have a value."""
 
 
-class KeyNotInContextError(Error):
+class KeyNotInContextError(ContextError):
     """Key not found in the pypyr context."""
 
 

--- a/pypyr/errors.py
+++ b/pypyr/errors.py
@@ -8,6 +8,14 @@ class Error(Exception):
     """Base class for all pypyr exceptions."""
 
 
+class KeyInContextHasNoValueError(Error):
+    """pypyr context[key] doesn't have a value."""
+
+
+class KeyNotInContextError(Error):
+    """Key not found in the pypyr context."""
+
+
 class PipelineNotFoundError(Error):
     """Pipeline not found in working dir or in pypyr install dir."""
 

--- a/pypyr/steps/contextclear.py
+++ b/pypyr/steps/contextclear.py
@@ -27,6 +27,7 @@ def run_step(context):
         contextClear:
             - key2
             - key4
+            - contextClear
 
     This will result in return context:
         key1: value1

--- a/pypyr/steps/contextclear.py
+++ b/pypyr/steps/contextclear.py
@@ -13,9 +13,11 @@ logger = pypyr.log.logger.get_logger(__name__)
 def run_step(context):
     """Remove specified keys from context.
 
-    Context is a dictionary or dictionary-like.
-    context['contextClear'] must exist. It's a dictionary.
-    Will iterate context['contextClear'] and remove those keys from context.
+    Args:
+        Context is a dictionary or dictionary-like.
+        context['contextClear'] must exist. It's a dictionary.
+        Will iterate context['contextClear'] and remove those keys from
+        context.
 
     For example, say input context is:
         key1: value1
@@ -38,5 +40,6 @@ def run_step(context):
         # slightly unorthodox pop returning None means you don't get a KeyError
         # if key doesn't exist
         context.pop(k, None)
+        logger.info(f"removed {k} from context")
 
     logger.debug("done")

--- a/pypyr/steps/contextclear.py
+++ b/pypyr/steps/contextclear.py
@@ -1,0 +1,42 @@
+"""pypyr step that clears context values.
+
+This is handy if you run the same step multiple times in a pipeline and you
+don't want the previously assigned context settings for that step to impact the
+next iteration.
+"""
+import pypyr.log.logger
+
+# logger means the log level will be set correctly
+logger = pypyr.log.logger.get_logger(__name__)
+
+
+def run_step(context):
+    """Remove specified keys from context.
+
+    Context is a dictionary or dictionary-like.
+    context['contextClear'] must exist. It's a dictionary.
+    Will iterate context['contextClear'] and remove those keys from context.
+
+    For example, say input context is:
+        key1: value1
+        key2: value2
+        key3: value3
+        key4: value4
+        contextClear:
+            - key2
+            - key4
+
+    This will result in return context:
+        key1: value1
+        key3: value3
+    """
+    logger.debug("started")
+    context.assert_key_has_value(key='contextClear', caller=__name__)
+
+    for k in context['contextClear']:
+        logger.debug(f"removing {k} from context")
+        # slightly unorthodox pop returning None means you don't get a KeyError
+        # if key doesn't exist
+        context.pop(k, None)
+
+    logger.debug("done")

--- a/pypyr/steps/contextclearall.py
+++ b/pypyr/steps/contextclearall.py
@@ -1,0 +1,21 @@
+"""pypyr step that wipes the entire context."""
+import pypyr.context
+import pypyr.log.logger
+
+# logger means the log level will be set correctly
+logger = pypyr.log.logger.get_logger(__name__)
+
+
+def run_step(context):
+    """Wipe the entire context.
+
+    Args:
+        Context is a dictionary or dictionary-like.
+        Does not require any specific keys in context.
+    """
+    logger.debug("started")
+
+    context.clear()
+    logger.info(f"Context wiped. New context size: {len(context)}")
+
+    logger.debug("done")

--- a/pypyr/steps/echo.py
+++ b/pypyr/steps/echo.py
@@ -22,7 +22,7 @@ def run_step(context):
     assert context, ("context must be set for echo. Did you set "
                      "--context 'echoMe=text here'?")
 
-    context.assert_key_has_value('echoMe', __name__)
+    context.assert_key_exists('echoMe', __name__)
 
     if isinstance(context['echoMe'], str):
         val = context.get_formatted('echoMe')

--- a/pypyr/steps/echo.py
+++ b/pypyr/steps/echo.py
@@ -8,20 +8,27 @@ logger = pypyr.log.logger.get_logger(__name__)
 def run_step(context):
     """Simple echo. Outputs context['echoMe'].
 
-    Context is a dictionary or dictionary-like.
-    If context contains 'echoMe' will echo the value to logger. This could well
-    be stdout.
+    Args:
+        context: dictionary-like. context is mandatory.
+                 context must contain key 'echoMe'
+                 context['echoMe'] will echo the value to logger.
+                 This logger could well be stdout.
 
-    context is mandatory. When you execute the pipeline, it should look
-    something like this: pipeline-runner [name here] --context 'echoMe=test'.
+    When you execute the pipeline, it should look something like this:
+    pypyr [name here] --context 'echoMe=test'.
     """
     logger.debug("started")
+
     assert context, ("context must be set for echo. Did you set "
                      "--context 'echoMe=text here'?")
 
-    val = context['echoMe'] if isinstance(
-        context['echoMe'], str) else repr(context['echoMe'])
+    context.assert_key_has_value('echoMe', __name__)
 
-    logger.info(context.get_formatted_string(val))
+    if isinstance(context['echoMe'], str):
+        val = context.get_formatted('echoMe')
+    else:
+        val = context['echoMe']
+
+    logger.info(val)
 
     logger.debug("done")

--- a/pypyr/steps/py.py
+++ b/pypyr/steps/py.py
@@ -26,16 +26,10 @@ def run_step(context):
     locals_dictionary = locals()
     exec(context['pycode'], globals(), locals_dictionary)
 
-    try:
-        # It looks like this dance might be unnecessary in python 3.6
-        logger.debug("looking for context update in exec")
-        exec_context = locals_dictionary['context']
-        context.update(exec_context)
-        logger.debug("exec output context merged with pipeline context")
-    except KeyError:
-        # there wouldn't be a context key if the yaml didn't do anything with
-        # it
-        logger.debug("exec didn't alter context")
-        pass
+    # It looks like this dance might be unnecessary in python 3.6
+    logger.debug("looking for context update in exec")
+    exec_context = locals_dictionary['context']
+    context.update(exec_context)
+    logger.debug("exec output context merged with pipeline context")
 
     logger.debug("done")

--- a/pypyr/steps/tar.py
+++ b/pypyr/steps/tar.py
@@ -40,8 +40,8 @@ def run_step(context):
 
     # at least 1 of tarExtract or tarArchive must exist in context
     tarExtract, tarArchive = context.keys_of_type_exist(
-        ('tarExtract', dict),
-        ('tarArchive', dict)
+        ('tarExtract', list),
+        ('tarArchive', list)
     )
     found_at_least_one = False
 
@@ -106,8 +106,10 @@ def tar_archive(context):
 
     Example:
         tarArchive:
-            path/to/dir: path/to/destination.tar.xs
-            another/my.file: ./my.tar.xs
+            - in: path/to/dir
+              out: path/to/destination.tar.xs
+            - in: another/my.file
+              out: ./my.tar.xs
 
         This will archive directory path/to/dir to path/to/destination.tar.xs,
         and also archive file another/my.file to ./my.tar.xs
@@ -116,11 +118,11 @@ def tar_archive(context):
 
     mode = get_file_mode_for_writing(context)
 
-    for k, v in context['tarArchive'].items():
+    for item in context['tarArchive']:
         # value is the destination tar. Allow string interpolation.
-        destination = context.get_formatted_string(v)
+        destination = context.get_formatted_string(item['out'])
         # key is the source to archive
-        source = context.get_formatted_string(k)
+        source = context.get_formatted_string(item['in'])
         with tarfile.open(destination, mode) as archive_me:
             logger.debug(f"Archiving '{source}' to '{destination}'")
 
@@ -141,8 +143,10 @@ def tar_extract(context):
 
     Example:
         tarExtract:
-            path/to/my.tar.xs: /path/extract/here
-            another/tar.xs: .
+            - in: path/to/my.tar.xs
+              out: /path/extract/here
+            - in: another/tar.xs
+              out: .
 
         This will extract path/to/my.tar.xs to /path/extract/here, and also
         extract another/tar.xs to $PWD.
@@ -151,11 +155,12 @@ def tar_extract(context):
 
     mode = get_file_mode_for_reading(context)
 
-    for k, v in context['tarExtract'].items():
-        # key is the path to the tar to extract
-        source = context.get_formatted_string(k)
-        # value is the outdir
-        destination = context.get_formatted_string(v)
+    for item in context['tarExtract']:
+        print(item)
+        # in is the path to the tar to extract. Allows string interpolation.
+        source = context.get_formatted_string(item['in'])
+        # out is the outdir, dhur. Allows string interpolation.
+        destination = context.get_formatted_string(item['out'])
         with tarfile.open(source, mode) as extract_me:
             logger.debug(f"Extracting '{source}' to '{destination}'")
 

--- a/pypyr/steps/tar.py
+++ b/pypyr/steps/tar.py
@@ -1,0 +1,165 @@
+"""Archive and extract tars."""
+import pypyr.log.logger
+from pypyr.errors import KeyNotInContextError
+import tarfile
+
+# logger means the log level will be set correctly
+logger = pypyr.log.logger.get_logger(__name__)
+
+
+def run_step(context):
+    """Archive and/or extract tars with or without compression.
+
+    Args:
+        context: dictionary-like. Mandatory.
+
+        At least one of these context keys must exist:
+        context['tarExtract']
+        context['tarArchive']
+
+        Optional:
+        context['tarFormat'] - if not specified, defaults to lzma/xz
+                               Available options:
+                                - '' - no compression
+                                - gz (gzip)
+                                - bz2 (bzip2)
+                                - xz (lzma)
+
+    This step will run whatever combination of Extract and Archive you specify.
+    Regardless of combination, execution order is Extract, Archive.
+
+    Source and destination paths support {key} string interpolation.
+
+    Never extract archives from untrusted sources without prior inspection.
+    It is possible that files are created outside of path, e.g. members that
+    have absolute filenames starting with "/" or filenames with two dots "..".
+    """
+    logger.debug("started")
+
+    assert context, f"context must have value for {__name__}"
+
+    # at least 1 of tarExtract or tarArchive must exist in context
+    tarExtract, tarArchive = context.keys_of_type_exist(
+        ('tarExtract', dict),
+        ('tarArchive', dict)
+    )
+    found_at_least_one = False
+
+    if tarExtract.key_in_context and tarExtract.is_expected_type:
+        found_at_least_one = True
+        tar_extract(context)
+
+    if tarArchive.key_in_context and tarArchive.is_expected_type:
+        found_at_least_one = True
+        tar_archive(context)
+
+    if not found_at_least_one:
+        # This will raise exception on first item with a problem.
+        context.assert_keys_type_value(__name__,
+                                       ('This step needs any combination of '
+                                        'tarExtract or tarArchive in context.'
+                                        ),
+                                       tarExtract,
+                                       tarArchive)
+
+    logger.debug("done")
+
+
+def get_file_mode_for_reading(context):
+    """Get file mode for reading from context['tarFormat'].
+
+    This should return r:*, r:gz, r:bz2 or r:xz. If user specified something
+    wacky in tarFormat, that's their business.
+
+    In theory r:* will auto-deduce the correct format.
+    """
+    try:
+        mode = f"r:{context['tarFormat']}"
+    except KeyNotInContextError:
+        mode = 'r:*'
+
+    return mode
+
+
+def get_file_mode_for_writing(context):
+    """Get file mode for writing from context['tarFormat']
+
+    This should return w:, w:gz, w:bz2 or w:xz. If user specified something
+    wacky in tarFormat, that's their business.
+    """
+    try:
+        mode = f"w:{context['tarFormat']}"
+    except KeyNotInContextError:
+        mode = 'w:xz'
+
+    return mode
+
+
+def tar_archive(context):
+    """Archive specified path to a tar archive.
+
+    Args:
+        context: dictionary-like. context is mandatory.
+            context['tarArchive'] must exist. It's a dictionary.
+            keys are the paths to archive.
+            values are the destination output paths.
+
+    Example:
+        tarArchive:
+            path/to/dir: path/to/destination.tar.xs
+            another/my.file: ./my.tar.xs
+
+        This will archive directory path/to/dir to path/to/destination.tar.xs,
+        and also archive file another/my.file to ./my.tar.xs
+    """
+    logger.debug("start")
+
+    mode = get_file_mode_for_writing(context)
+
+    for k, v in context['tarArchive'].items():
+        # value is the destination tar. Allow string interpolation.
+        destination = context.get_formatted_string(v)
+        # key is the source to archive
+        source = context.get_formatted_string(k)
+        with tarfile.open(destination, mode) as archive_me:
+            logger.debug(f"Archiving '{source}' to '{destination}'")
+
+            archive_me.add(source)
+            logger.info(f"Archived '{source}' to '{destination}'")
+
+    logger.debug("end")
+
+
+def tar_extract(context):
+    """Extract all members of tar archive to specified path.
+
+    Args:
+        context: dictionary-like. context is mandatory.
+            context['tarExtract'] must exist. It's a dictionary.
+            keys are the path to the tar to extract.
+            values are the destination paths.
+
+    Example:
+        tarExtract:
+            path/to/my.tar.xs: /path/extract/here
+            another/tar.xs: .
+
+        This will extract path/to/my.tar.xs to /path/extract/here, and also
+        extract another/tar.xs to $PWD.
+    """
+    logger.debug("start")
+
+    mode = get_file_mode_for_reading(context)
+
+    for k, v in context['tarExtract'].items():
+        # key is the path to the tar to extract
+        source = context.get_formatted_string(k)
+        # value is the outdir
+        destination = context.get_formatted_string(v)
+        with tarfile.open(source, mode) as extract_me:
+            logger.debug(f"Extracting '{source}' to '{destination}'")
+
+            extract_me.extractall(destination)
+            logger.info(f"Extracted '{source}' to '{destination}'")
+
+    logger.debug("end")

--- a/pypyr/steps/tar.py
+++ b/pypyr/steps/tar.py
@@ -156,7 +156,6 @@ def tar_extract(context):
     mode = get_file_mode_for_reading(context)
 
     for item in context['tarExtract']:
-        print(item)
         # in is the path to the tar to extract. Allows string interpolation.
         source = context.get_formatted_string(item['in'])
         # out is the outdir, dhur. Allows string interpolation.

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -37,7 +37,7 @@ def get_pipeline_steps(pipeline, steps_group):
                      "pipeline definition.")
 
         logger.debug("done")
-        return pipeline[steps_group]
+        return steps
     else:
         logger.debug(
             f"pipeline doesn't have a {steps_group} collection. Add a "

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -97,16 +97,9 @@ def run_pipeline_step(step_name, context):
 
     try:
         logger.debug(f"running step {step}")
-        in_context_is_set = bool(context)
+
         step.run_step(context)
 
-        if in_context_is_set:
-            # only ensure result is not empty if input wasn't empty. This is to
-            # make sure step doesn't kill the context for downstream.
-            assert (context), (
-                f"{step_name} returned None context. At the very least it must"
-                " return an empty dictionary. Is the step super-sure it really"
-                " wants to nuke the context for all subsequent steps?")
         logger.debug(f"step {step} done")
     except AttributeError:
         logger.error(f"The step {step_name} doesn't have a run_step(context) "

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -123,7 +123,8 @@ def run_pipeline_steps(steps, context):
                 logger.debug(f"{step} is complex.")
                 step_name = step['name']
 
-                get_step_input_context(step['in'], context)
+                if 'in' in step:
+                    get_step_input_context(step['in'], context)
             else:
                 logger.debug(f"{step} is a simple string.")
                 step_name = step

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -108,6 +108,18 @@ def test_assert_key_has_value_passes():
     context.assert_key_has_value('key1', None)
 
 
+def test_assert_key_has_bool_true_passes():
+    """Pass if key_in_dict_has_value dictionary key has bool True value."""
+    context = Context({'key1': True})
+    context.assert_key_has_value('key1', None)
+
+
+def test_assert_key_has_bool_false_passes():
+    """Pass if key_in_dict_has_value dictionary key has bool False value."""
+    context = Context({'key1': False})
+    context.assert_key_has_value('key1', None)
+
+
 def test_assert_keys_have_values_passes():
     """Pass if list of keys all found in context dictionary."""
     context = Context({'key1': 'value1', 'key2': 'value2', 'key3': 'value3'})

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -490,6 +490,7 @@ def test_keys_of_type_exist_single():
     assert k1.key_in_context
     assert k1.expected_type is str
     assert k1.is_expected_type
+    assert k1.has_value
 
 
 def test_keys_of_type_exist_triple():
@@ -506,18 +507,21 @@ def test_keys_of_type_exist_triple():
     assert k1.key_in_context
     assert k1.expected_type is str
     assert k1.is_expected_type
+    assert k1.has_value
 
     assert k2
     assert k2.key == 'k2'
     assert k2.key_in_context
     assert k2.expected_type is list
     assert not k2.is_expected_type
+    assert k2.has_value
 
     assert k3
     assert k3.key == 'k3'
     assert k3.key_in_context
     assert k3.expected_type is list
     assert k3.is_expected_type
+    assert k3.has_value
 
 
 def test_keys_none_exist():
@@ -537,18 +541,20 @@ def test_keys_none_exist():
     assert not k4.key_in_context
     assert k4.expected_type is list
     assert k4.is_expected_type is None
+    assert not k4.has_value
 
     assert k5
     assert k5.key == 'k5'
     assert not k5.key_in_context
     assert k5.expected_type is bool
-    assert k4.is_expected_type is None
+    assert k5.is_expected_type is None
+    assert not k5.has_value
 
     assert k6
     assert k6.key == 'k6'
     assert not k6.key_in_context
     assert k6.expected_type is list
     assert k6.is_expected_type is None
-
+    assert not k6.has_value
 
 # ------------------- key info -----------------------------------------------#

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -1,6 +1,6 @@
 """context.py unit tests."""
 from collections.abc import MutableMapping
-from pypyr.context import Context
+from pypyr.context import Context, ContextItemInfo
 from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
 import pytest
 
@@ -185,6 +185,195 @@ def test_assert_keys_have_values_fails():
                                         'key4',
                                         'key2',
                                         )
+
+
+def test_assert_key_type_value_passes():
+    """assert_key_type_value passes if key exists, has value and type right."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=True,
+                           expected_type=str,
+                           is_expected_type=True,
+                           has_value=True)
+
+    Context().assert_key_type_value(info, None)
+
+
+def test_assert_key_type_value_no_key_raises():
+    """assert_key_type_value fails if key doesn't exist."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=False,
+                           expected_type=str,
+                           is_expected_type=True,
+                           has_value=True)
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        Context().assert_key_type_value(info, 'mydesc')
+
+    assert repr(err_info.value) == (
+        "KeyNotInContextError(\"mydesc couldn't find key1 in context.\",)")
+
+
+def test_assert_key_type_value_no_key_raises_extra_text():
+    """assert_key_type_value fails if key doesn't exist."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=False,
+                           expected_type=str,
+                           is_expected_type=True,
+                           has_value=True)
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        Context().assert_key_type_value(info, 'mydesc', 'extra text here')
+
+    assert repr(err_info.value) == (
+        "KeyNotInContextError(\"mydesc couldn't find key1 in context. extra "
+        "text here\",)")
+
+
+def test_assert_key_type_value_no_value_raises():
+    """assert_key_type_value fails if no value."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=True,
+                           expected_type=str,
+                           is_expected_type=True,
+                           has_value=False)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        Context().assert_key_type_value(info, 'mydesc')
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"mydesc found key1 in context but it "
+        "doesn\'t have a value.\",)")
+
+
+def test_assert_key_type_value_no_value_raises_extra_text():
+    """assert_key_type_value fails if no value."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=True,
+                           expected_type=str,
+                           is_expected_type=True,
+                           has_value=False)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        Context().assert_key_type_value(info, 'mydesc', 'extra text here')
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"mydesc found key1 in context but it "
+        "doesn\'t have a value. extra text here\",)")
+
+
+def test_assert_key_type_value_wrong_type_raises():
+    """assert_key_type_value fails if wrong type."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=True,
+                           expected_type=str,
+                           is_expected_type=False,
+                           has_value=True)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        Context().assert_key_type_value(info, 'mydesc')
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"mydesc found key1 in context, but "
+        "it\'s not a <class 'str'>.\",)")
+
+
+def test_assert_key_type_value_wrong_type_raises_with_extra_error_text():
+    """assert_key_type_value fails if wrong type."""
+    info = ContextItemInfo(key='key1',
+                           key_in_context=True,
+                           expected_type=str,
+                           is_expected_type=False,
+                           has_value=True)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        Context().assert_key_type_value(info, 'mydesc', 'extra text here')
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"mydesc found key1 in context, but "
+        "it\'s not a <class 'str'>. extra text here\",)")
+
+
+def test_assert_keys_type_value_passes():
+    """assert_keys_type_value passes if all keys, types, values correct."""
+    info1 = ContextItemInfo(key='key1',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    info2 = ContextItemInfo(key='key2',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    info3 = ContextItemInfo(key='key3',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    Context().assert_keys_type_value(None, '', info1, info2, info3)
+
+
+def test_assert_keys_type_value_raises():
+    """assert_keys_type_value raises if issue with one in the middle."""
+    info1 = ContextItemInfo(key='key1',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    info2 = ContextItemInfo(key='key2',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=False)
+
+    info3 = ContextItemInfo(key='key3',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        Context().assert_keys_type_value('mydesc', None, info1, info2, info3)
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"mydesc found key2 in context but it "
+        "doesn\'t have a value.\",)")
+
+
+def test_assert_keys_type_value_raises_with_extra_error_text():
+    """assert_keys_type_value raises if issue with one in the middle."""
+    info1 = ContextItemInfo(key='key1',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    info2 = ContextItemInfo(key='key2',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=False)
+
+    info3 = ContextItemInfo(key='key3',
+                            key_in_context=True,
+                            expected_type=str,
+                            is_expected_type=True,
+                            has_value=True)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        Context().assert_keys_type_value('mydesc',
+                                         'extra text here',
+                                         info1,
+                                         info2,
+                                         info3)
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"mydesc found key2 in context but it "
+        "doesn\'t have a value. extra text here\",)")
 
 # ------------------- asserts ------------------------------------------------#
 

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -59,6 +59,15 @@ def test_context_is_dictionary_like():
     d.update(mergedic)
     assert d['k1'] == 'NEWVALUE'
 
+    # del and clear
+    original_length = len(d)
+    del d['k1']
+    assert 'k1' not in d
+    assert len(d) == original_length - 1
+
+    d.clear()
+    assert len(d) == 0
+
 
 def test_context_missing_override():
     """Subclass of dict should override __missing__ on KeyNotFound"""

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -441,10 +441,14 @@ def test_tag_not_in_context_should_throw():
 
 
 def test_context_item_not_a_string_should_throw():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as err_info:
         context = Context({'key1': 'value1'})
         context['input_string'] = 77
         context.get_formatted('input_string')
+
+    assert repr(err_info.value) == (
+        "TypeError(\"can only format on strings. 77 is a <class 'int'> "
+        "instead.\",)")
 
 
 def test_input_string_interpolate_works():
@@ -468,10 +472,14 @@ def test_input_string_tag_not_in_context_should_throw():
 
 
 def test_input_string_not_a_string_throw():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as err_info:
         context = Context({'key1': 'value1'})
         input_string = 77
         context.get_formatted_string(input_string)
+
+    assert repr(err_info.value) == (
+        "TypeError(\"can only format on strings. 77 is a <class 'int'> "
+        "instead.\",)")
 # ------------------- formats ------------------------------------------------#
 
 # ------------------- key info -----------------------------------------------#

--- a/tests/unit/pypyr/errors_test.py
+++ b/tests/unit/pypyr/errors_test.py
@@ -1,6 +1,7 @@
 """errors.py unit tests."""
 from pypyr.errors import Error as PypyrError
 from pypyr.errors import (
+    ContextError,
     KeyInContextHasNoValueError,
     KeyNotInContextError,
     PlugInError,
@@ -20,10 +21,22 @@ def test_base_error_raises():
                                     "right here',)")
 
 
+def test_context_error_raises():
+    """ContextError raises with correct message"""
+    assert isinstance(ContextError(), PypyrError)
+
+    with pytest.raises(ContextError) as err_info:
+        raise ContextError("this is error text right here")
+
+    assert repr(err_info.value) == ("ContextError('this is error "
+                                    "text right here',)")
+
+
 def test_key_not_in_context_error_raises():
     """Key not in context error raises with correct message."""
     # confirm subclassed from pypyr root error
     assert isinstance(KeyNotInContextError(), PypyrError)
+    assert isinstance(KeyNotInContextError(), ContextError)
 
     with pytest.raises(KeyNotInContextError) as err_info:
         raise KeyNotInContextError("this is error text right here")
@@ -36,6 +49,7 @@ def test_key_in_context_has_no_value_error_raises():
     """Key not in context value error raises with correct message."""
     # confirm subclassed from pypyr root error
     assert isinstance(KeyInContextHasNoValueError(), PypyrError)
+    assert isinstance(KeyNotInContextError(), ContextError)
 
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         raise KeyInContextHasNoValueError("this is error text right here")

--- a/tests/unit/pypyr/errors_test.py
+++ b/tests/unit/pypyr/errors_test.py
@@ -1,8 +1,11 @@
 """errors.py unit tests."""
 from pypyr.errors import Error as PypyrError
-from pypyr.errors import (PlugInError,
-                          PipelineNotFoundError,
-                          PyModuleNotFoundError)
+from pypyr.errors import (
+    KeyInContextHasNoValueError,
+    KeyNotInContextError,
+    PlugInError,
+    PipelineNotFoundError,
+    PyModuleNotFoundError)
 import pytest
 
 
@@ -17,16 +20,29 @@ def test_base_error_raises():
                                     "right here',)")
 
 
-def test_plugin_error_raises():
-    """Pypyr plugin error raises with correct message."""
+def test_key_not_in_context_error_raises():
+    """Key not in context error raises with correct message."""
     # confirm subclassed from pypyr root error
-    assert isinstance(PlugInError(), PypyrError)
+    assert isinstance(KeyNotInContextError(), PypyrError)
 
-    with pytest.raises(PlugInError) as err_info:
-        raise PlugInError("this is error text right here")
+    with pytest.raises(KeyNotInContextError) as err_info:
+        raise KeyNotInContextError("this is error text right here")
 
-    assert repr(err_info.value) == ("PlugInError('this is error "
+    assert repr(err_info.value) == ("KeyNotInContextError('this is error "
                                     "text right here',)")
+
+
+def test_key_in_context_has_no_value_error_raises():
+    """Key not in context value error raises with correct message."""
+    # confirm subclassed from pypyr root error
+    assert isinstance(KeyInContextHasNoValueError(), PypyrError)
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        raise KeyInContextHasNoValueError("this is error text right here")
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError('this is error "
+        "text right here',)")
 
 
 def test_pipeline_not_found_error_raises():
@@ -38,6 +54,18 @@ def test_pipeline_not_found_error_raises():
         raise PipelineNotFoundError("this is error text right here")
 
     assert repr(err_info.value) == ("PipelineNotFoundError('this is error "
+                                    "text right here',)")
+
+
+def test_plugin_error_raises():
+    """Pypyr plugin error raises with correct message."""
+    # confirm subclassed from pypyr root error
+    assert isinstance(PlugInError(), PypyrError)
+
+    with pytest.raises(PlugInError) as err_info:
+        raise PlugInError("this is error text right here")
+
+    assert repr(err_info.value) == ("PlugInError('this is error "
                                     "text right here',)")
 
 

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -1,6 +1,230 @@
 """pipelinerunner.py unit tests."""
 import os
+from pypyr.context import Context
+from pypyr.errors import (ContextError,
+                          KeyNotInContextError,
+                          PyModuleNotFoundError)
 import pypyr.pipelinerunner
+import pytest
+from unittest.mock import call, mock_open, patch
+
+# ------------------------- parser mocks -------------------------------------#
+
+
+def mock_parser(context_arg):
+    """Arbitrary mock function to execute instead of get_parsed_context"""
+    return Context({'key1': 'created in mock parser', 'key2': context_arg})
+
+
+def mock_parser_none(context_arg):
+    """Return None, mocking get_parsed_context"""
+    print('FUCK YOU CUNT')
+    return None
+# ------------------------- parser mocks -------------------------------------#
+
+# ------------------------- get_parsed_context--------------------------------#
+
+
+def test_get_parsed_context_no_parser():
+    """get_parsed_context returns empty Context when no parser specified."""
+    context = pypyr.pipelinerunner.get_parsed_context({}, None)
+
+    assert isinstance(context, Context)
+    assert len(context) == 0
+
+
+def test_get_parsed_context_parser_not_found():
+    """get_parsed_context raises if parser module specified but not found."""
+    with pytest.raises(PyModuleNotFoundError):
+        pypyr.pipelinerunner.get_parsed_context(
+            {'context_parser': 'unlikelyblahmodulenameherexxssz'}, None)
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_get_parsed_context_parser_returns_none(mocked_moduleloader):
+    """get_parsed_context returns empty Context when parser returns None."""
+    mocked_moduleloader.return_value.get_parsed_context = mock_parser_none
+
+    context = pypyr.pipelinerunner.get_parsed_context(
+        {'context_parser': 'specifiedparserhere'}, 'in arg here')
+
+    mocked_moduleloader.assert_called_once_with('specifiedparserhere')
+
+    assert isinstance(context, Context)
+    assert len(context) == 0
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_get_parsed_context_parser_pass(mocked_moduleloader):
+    """get_parsed_context passes arg param and returns context."""
+    mocked_moduleloader.return_value.get_parsed_context = mock_parser
+
+    context = pypyr.pipelinerunner.get_parsed_context(
+        {'context_parser': 'specifiedparserhere'}, 'in arg here')
+
+    mocked_moduleloader.assert_called_once_with('specifiedparserhere')
+
+    assert isinstance(context, Context)
+    assert len(context) == 2
+    context['key1'] == 'created in mock parser'
+    context['key2'] == 'in arg here'
+
+
+@patch('pypyr.moduleloader.get_module', return_value=3)
+def test_get_parser_context_signature_wrong(mocked_moduleloader):
+    """Raise when parser found but no get_parsed_context attr."""
+    with pytest.raises(AttributeError) as err_info:
+        pypyr.pipelinerunner.get_parsed_context(
+            {'context_parser': 'specifiedparserhere'}, 'in arg here')
+
+    assert repr(err_info.value) == (
+        "AttributeError(\"'int' object has no attribute "
+        "'get_parsed_context'\",)")
+
+# ------------------------- get_parsed_context--------------------------------#
+
+# ------------------------- get_pipeline_definition --------------------------#
+
+
+@patch('ruamel.yaml.safe_load', return_value='mocked pipeline def')
+@patch('pypyr.moduleloader.get_pipeline_path', return_value='arb/path/x.yaml')
+def test_get_pipeline_definition_pass(mocked_get_path,
+                                      mocked_yaml):
+    """get_pipeline_definition passes correct params to all methods."""
+    with patch('pypyr.pipelinerunner.open',
+               mock_open(read_data='pipe contents')) as mocked_open:
+        pipeline_def = pypyr.pipelinerunner.get_pipeline_definition(
+            'pipename', '/working/dir')
+
+    assert pipeline_def == 'mocked pipeline def'
+    mocked_get_path.assert_called_once_with(
+        pipeline_name='pipename', working_directory='/working/dir')
+    mocked_open.assert_called_once_with('arb/path/x.yaml')
+    mocked_yaml.assert_called_once_with(mocked_open.return_value)
+
+
+@patch('pypyr.moduleloader.get_pipeline_path', return_value='arb/path/x.yaml')
+def test_get_pipeline_definition_file_not_found(mocked_get_path):
+    """get_pipeline_definition raises file not found."""
+    with patch('pypyr.pipelinerunner.open',
+               mock_open(read_data='pipe contents')) as mocked_open:
+        mocked_open.side_effect = FileNotFoundError('deliberate err')
+        with pytest.raises(FileNotFoundError):
+            pypyr.pipelinerunner.get_pipeline_definition(
+                'pipename', '/working/dir')
+
+# ------------------------- get_pipeline_definition --------------------------#
+
+# ------------------------- main ---------------------------------------------#
+
+
+@patch('pypyr.stepsrunner.run_step_group')
+@patch('pypyr.pipelinerunner.get_parsed_context',
+       return_value='parsed context')
+@patch('pypyr.pipelinerunner.get_pipeline_definition', return_value='pipe def')
+@patch('pypyr.moduleloader.set_working_directory')
+def test_get_main_pass(mocked_work_dir,
+                       mocked_get_pipe_def,
+                       mocked_get_parsed_context,
+                       mocked_run_step_group):
+    """main passes correct params to all methods"""
+
+    pypyr.pipelinerunner.main(pipeline_name='arb pipe',
+                              pipeline_context_input='arb context input',
+                              working_dir='arb/dir',
+                              log_level=77)
+
+    mocked_work_dir.assert_called_once_with('arb/dir')
+    mocked_get_pipe_def.assert_called_once_with(pipeline_name='arb pipe',
+                                                working_dir='arb/dir')
+    mocked_get_parsed_context.assert_called_once_with(
+        pipeline='pipe def',
+        context_in_string='arb context input')
+
+    # 1st called steps, then on_success
+    expected_run_step_groups = [call(context='parsed context',
+                                     pipeline_definition='pipe def',
+                                     step_group_name='steps'),
+                                call(context='parsed context',
+                                     pipeline_definition='pipe def',
+                                     step_group_name='on_success')]
+
+    mocked_run_step_group.assert_has_calls(expected_run_step_groups)
+
+
+@patch('pypyr.stepsrunner.run_step_group')
+@patch('pypyr.pipelinerunner.get_parsed_context',
+       return_value='parsed context')
+@patch('pypyr.pipelinerunner.get_pipeline_definition', return_value='pipe def')
+@patch('pypyr.moduleloader.set_working_directory')
+def test_get_main_parse_context_error(mocked_work_dir,
+                                      mocked_get_pipe_def,
+                                      mocked_get_parsed_context,
+                                      mocked_run_step_group):
+    """main runs on_failure with {} dict if context parse fails."""
+    mocked_get_parsed_context.side_effect = ContextError
+
+    with pytest.raises(ContextError):
+        pypyr.pipelinerunner.main(pipeline_name='arb pipe',
+                                  pipeline_context_input='arb context input',
+                                  working_dir='arb/dir',
+                                  log_level=77)
+
+    mocked_work_dir.assert_called_once_with('arb/dir')
+    mocked_get_pipe_def.assert_called_once_with(pipeline_name='arb pipe',
+                                                working_dir='arb/dir')
+    mocked_get_parsed_context.assert_called_once_with(
+        pipeline='pipe def',
+        context_in_string='arb context input')
+
+    # No called steps, just on_failure since err on parse context already
+    expected_run_step_groups = [call(context={},
+                                     pipeline_definition='pipe def',
+                                     step_group_name='on_failure')]
+
+    mocked_run_step_group.assert_has_calls(expected_run_step_groups)
+
+
+@patch('pypyr.stepsrunner.run_step_group')
+@patch('pypyr.pipelinerunner.get_parsed_context',
+       return_value='parsed context')
+@patch('pypyr.pipelinerunner.get_pipeline_definition', return_value='pipe def')
+@patch('pypyr.moduleloader.set_working_directory')
+def test_get_main_steps_error(mocked_work_dir,
+                              mocked_get_pipe_def,
+                              mocked_get_parsed_context,
+                              mocked_run_step_group):
+    """main runs on_failure if steps group fails."""
+    # First time it runs is steps - give a KeyNotInContextError. After that it
+    # runs again to process the failure condition - thus None.
+    mocked_run_step_group.side_effect = [KeyNotInContextError, None]
+
+    with pytest.raises(KeyNotInContextError):
+        pypyr.pipelinerunner.main(pipeline_name='arb pipe',
+                                  pipeline_context_input='arb context input',
+                                  working_dir='arb/dir',
+                                  log_level=77)
+
+    mocked_work_dir.assert_called_once_with('arb/dir')
+    mocked_get_pipe_def.assert_called_once_with(pipeline_name='arb pipe',
+                                                working_dir='arb/dir')
+    mocked_get_parsed_context.assert_called_once_with(
+        pipeline='pipe def',
+        context_in_string='arb context input')
+
+    # 1st called steps, then on_success
+    expected_run_step_groups = [call(context='parsed context',
+                                     pipeline_definition='pipe def',
+                                     step_group_name='steps'),
+                                call(context='parsed context',
+                                     pipeline_definition='pipe def',
+                                     step_group_name='on_failure')]
+
+    mocked_run_step_group.assert_has_calls(expected_run_step_groups)
+
+# ------------------------- main----------------------------------------------#
+
+# ------------------------- integration---------------------------------------#
 
 
 def test_pipeline_runner_main():
@@ -15,3 +239,4 @@ def test_pipeline_runner_main():
                               pipeline_context_input=None,
                               working_dir=working_dir,
                               log_level=50)
+# ------------------------- integration---------------------------------------#

--- a/tests/unit/pypyr/steps/contextclear_test.py
+++ b/tests/unit/pypyr/steps/contextclear_test.py
@@ -1,0 +1,73 @@
+"""contextclear.py unit tests."""
+from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
+import pypyr.steps.contextclear
+import pytest
+
+
+def test_context_clear_throws_on_empty_context():
+    """context must exist."""
+    with pytest.raises(KeyNotInContextError):
+        pypyr.steps.contextclear.run_step(Context())
+
+
+def test_context_clear_throws_on_contextset_missing():
+    """contextClear must exist in context."""
+    with pytest.raises(KeyNotInContextError):
+        pypyr.steps.contextclear.run_step(Context({'arbkey': 'arbvalue'}))
+
+
+def test_context_clear_pass():
+    """contextset success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'key4': 'value4',
+        'contextClear': [
+            'key2',
+            'key4',
+            'contextClear'
+        ]
+    })
+
+    pypyr.steps.contextclear.run_step(context)
+
+    assert len(context) == 2
+    assert context['key1'] == 'value1'
+    assert 'key2' not in context
+    assert context['key3'] == 'value3'
+    assert 'key4' not in context
+    # recursion ahoy
+    assert 'contextClear' not in context
+
+
+def test_context_clear_no_raise_if_keys_dont_exist():
+    """contextset passes even if keys not in context"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'key4': 'value4',
+        'contextClear': [
+            'key2',
+            'key4',
+            'key5',
+            'key1',
+        ]
+    })
+
+    pypyr.steps.contextclear.run_step(context)
+
+    assert len(context) == 2
+    assert 'key1' not in context
+    assert 'key2' not in context
+    assert context['key3'] == 'value3'
+    assert 'key4' not in context
+    # recursion ahoy
+    assert context['contextClear'] == [
+        'key2',
+        'key4',
+        'key5',
+        'key1',
+    ]

--- a/tests/unit/pypyr/steps/contextclearall_test.py
+++ b/tests/unit/pypyr/steps/contextclearall_test.py
@@ -1,0 +1,31 @@
+"""contextclearall.py unit tests."""
+from pypyr.context import Context
+import pypyr.steps.contextclearall
+
+
+def test_context_clear_all_pass():
+    """Context Clear All removes everything from context."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'key4': 'value4',
+        'contextClear': [
+            'key2',
+            'key4',
+            'contextClear'
+        ]
+    })
+
+    pypyr.steps.contextclearall.run_step(context)
+
+    assert len(context) == 0
+
+
+def test_context_clear_all_context_empty_already():
+    """Context Clear All removes everything from context from empty."""
+    context = Context()
+
+    pypyr.steps.contextclearall.run_step(context)
+
+    assert len(context) == 0

--- a/tests/unit/pypyr/steps/contextclearall_test.py
+++ b/tests/unit/pypyr/steps/contextclearall_test.py
@@ -21,6 +21,14 @@ def test_context_clear_all_pass():
 
     assert len(context) == 0
 
+    assert context is not None
+
+    assert isinstance(context, Context)
+
+    context['k1'] = 'value1'
+
+    assert context['k1'] == 'value1'
+
 
 def test_context_clear_all_context_empty_already():
     """Context Clear All removes everything from context from empty."""

--- a/tests/unit/pypyr/steps/contextset_test.py
+++ b/tests/unit/pypyr/steps/contextset_test.py
@@ -1,23 +1,25 @@
 """contextset.py unit tests."""
 from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
 import pypyr.steps.contextset
 import pytest
 
 
 def test_context_set_throws_on_empty_context():
     """context must exist."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(KeyNotInContextError):
         pypyr.steps.contextset.run_step(Context())
 
 
 def test_context_set_throws_on_contextset_missing():
     """contextSet must exist in context."""
-    with pytest.raises(AssertionError) as err_info:
+    with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.contextset.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == ("AssertionError(\"context['contextSet'] "
-                                    "doesn't exist. It must have a value for "
-                                    "pypyr.steps.contextset.\",)")
+    assert repr(err_info.value) == (
+        "KeyNotInContextError(\"context['contextSet'] "
+        "doesn't exist. It must exist for "
+        "pypyr.steps.contextset.\",)")
 
 
 def test_context_set_pass():

--- a/tests/unit/pypyr/steps/echo_test.py
+++ b/tests/unit/pypyr/steps/echo_test.py
@@ -1,0 +1,77 @@
+"""echo.py unit tests."""
+from pypyr.context import Context
+import pypyr.log.logger
+import pypyr.steps.echo
+import pytest
+from unittest.mock import patch
+
+
+def test_echo_pass():
+    """Echos echoMe in context."""
+    context = Context({
+        'echoMe': 'test value here'})
+
+    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.echo.run_step(context)
+
+    mock_logger_info.assert_called_once_with('test value here')
+
+
+def test_echo_substitutions_pass():
+    """Format string interpolations should work."""
+    context = Context({
+        'key1': 'down the',
+        'echoMe': 'piping {key1} valleys wild'})
+
+    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.echo.run_step(context)
+
+    mock_logger_info.assert_called_once_with('piping down the valleys wild')
+
+
+def test_echo_number_pass():
+    """An int should echo."""
+    context = Context({
+        'echoMe': 77})
+
+    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.echo.run_step(context)
+
+    mock_logger_info.assert_called_once_with(77)
+
+
+def test_echo_bool_pass():
+    """A bool should echo."""
+    context = Context({
+        'echoMe': False})
+
+    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.echo.run_step(context)
+
+    mock_logger_info.assert_called_once_with(False)
+
+
+def test_echo_empty_context_fails():
+    """Empty context fails."""
+    with pytest.raises(AssertionError) as err_info:
+        pypyr.steps.echo.run_step(None)
+
+    assert repr(err_info.value) == ("AssertionError(\"context must be set for "
+                                    "echo. Did you set --context 'echoMe=text "
+                                    "here'?\",)")
+
+
+def test_echo_missing_echo_me_raises():
+    """context must contain echoMe."""
+    context = Context({
+        'blah': 'blah blah'})
+    with pytest.raises(AssertionError) as err_info:
+        pypyr.steps.echo.run_step(context)
+
+    assert repr(err_info.value) == ("AssertionError(\"context['echoMe'] "
+                                    "doesn't exist. It must have a value for "
+                                    "pypyr.steps.echo.\",)")

--- a/tests/unit/pypyr/steps/echo_test.py
+++ b/tests/unit/pypyr/steps/echo_test.py
@@ -1,5 +1,6 @@
 """echo.py unit tests."""
 from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
 import pypyr.log.logger
 import pypyr.steps.echo
 import pytest
@@ -69,9 +70,19 @@ def test_echo_missing_echo_me_raises():
     """context must contain echoMe."""
     context = Context({
         'blah': 'blah blah'})
-    with pytest.raises(AssertionError) as err_info:
+    with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.echo.run_step(context)
 
-    assert repr(err_info.value) == ("AssertionError(\"context['echoMe'] "
-                                    "doesn't exist. It must have a value for "
+    assert repr(err_info.value) == ("KeyNotInContextError(\"context['echoMe'] "
+                                    "doesn't exist. It must exist for "
                                     "pypyr.steps.echo.\",)")
+
+
+def test_echo_echo_me_none_pass():
+    """Echo can output None."""
+    context = Context({'echoMe': None})
+    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.echo.run_step(context)
+
+    mock_logger_info.assert_called_once_with(None)

--- a/tests/unit/pypyr/steps/py_test.py
+++ b/tests/unit/pypyr/steps/py_test.py
@@ -1,5 +1,6 @@
 """py.py unit tests."""
 from pypyr.context import Context
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
 import pypyr.steps.py
 import pytest
 
@@ -51,17 +52,17 @@ def test_pycode_error_throws():
 
 def test_no_pycode_context_throw():
     """No pycode in context should throw assert error."""
-    with pytest.raises(AssertionError) as err_info:
+    with pytest.raises(KeyNotInContextError) as err_info:
         context = Context({'blah': 'blah blah'})
         pypyr.steps.py.run_step(context)
 
-    assert repr(err_info.value) == ("AssertionError(\"context['pycode'] "
-                                    "doesn't exist. It must have a value for "
+    assert repr(err_info.value) == ("KeyNotInContextError(\"context['pycode'] "
+                                    "doesn't exist. It must exist for "
                                     "pypyr.steps.py.\",)")
 
 
 def test_empty_pycode_context_throw():
     """Empty pycode in context should throw assert error."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(KeyInContextHasNoValueError):
         context = Context({'pycode': None})
         pypyr.steps.py.run_step(context)

--- a/tests/unit/pypyr/steps/safeshell_test.py
+++ b/tests/unit/pypyr/steps/safeshell_test.py
@@ -1,5 +1,6 @@
 """safeshell.py unit tests."""
 from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
 import pypyr.steps.safeshell
 import pytest
 import subprocess
@@ -46,10 +47,10 @@ def test_shell_error_throws():
 
 def test_empty_context_cmd_throw():
     """Empty cmd in context should throw assert error."""
-    with pytest.raises(AssertionError) as err_info:
+    with pytest.raises(KeyNotInContextError) as err_info:
         context = Context({'blah': 'blah blah'})
         pypyr.steps.safeshell.run_step(context)
 
-    assert repr(err_info.value) == ("AssertionError(\"context['cmd'] "
-                                    "doesn't exist. It must have a value for "
+    assert repr(err_info.value) == ("KeyNotInContextError(\"context['cmd'] "
+                                    "doesn't exist. It must exist for "
                                     "pypyr.steps.safeshell.\",)")

--- a/tests/unit/pypyr/steps/shell_test.py
+++ b/tests/unit/pypyr/steps/shell_test.py
@@ -1,5 +1,6 @@
 """shell.py unit tests."""
 from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
 import pypyr.steps.shell
 import pytest
 import subprocess
@@ -57,10 +58,10 @@ def test_shell_error_throws():
 
 def test_empty_context_cmd_throw():
     """Empty cmd in context should throw assert error."""
-    with pytest.raises(AssertionError) as err_info:
+    with pytest.raises(KeyNotInContextError) as err_info:
         context = Context({'blah': 'blah blah'})
         pypyr.steps.shell.run_step(context)
 
-    assert repr(err_info.value) == ("AssertionError(\"context['cmd'] "
-                                    "doesn't exist. It must have a value for "
+    assert repr(err_info.value) == ("KeyNotInContextError(\"context['cmd'] "
+                                    "doesn't exist. It must exist for "
                                     "pypyr.steps.shell.\",)")

--- a/tests/unit/pypyr/steps/tar_test.py
+++ b/tests/unit/pypyr/steps/tar_test.py
@@ -1,0 +1,345 @@
+"""tar.py unit tests."""
+from pypyr.context import Context
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
+import pypyr.steps.tar
+import pytest
+from unittest.mock import patch, DEFAULT
+
+# ------------------------- get file mode ------------------------------------#
+
+
+def test_get_file_mode_for_reading():
+    """File Mode for reading passes, with defaults."""
+    # if there's no tarFormat, r:*
+    assert 'r:*' == pypyr.steps.tar.get_file_mode_for_reading(Context())
+
+    # if there's a tarFormat, r:blah
+    assert 'r:blah' == pypyr.steps.tar.get_file_mode_for_reading(
+        Context({'tarFormat': 'blah'}))
+
+
+def test_get_file_mode_for_writing():
+    """File Mode for writing passes, with defaults."""
+    # if there's no tarFormat, r:*
+    assert 'w:xz' == pypyr.steps.tar.get_file_mode_for_writing(Context())
+
+    # if there's a tarFormat, r:blah
+    assert 'w:blah' == pypyr.steps.tar.get_file_mode_for_writing(
+        Context({'tarFormat': 'blah'}))
+
+# ------------------------- get file mode ------------------------------------#
+
+
+# ------------------------- tar base -----------------------------------------#
+
+
+def test_tar_throws_on_empty_context():
+    """context must exist."""
+    with pytest.raises(AssertionError) as err_info:
+        pypyr.steps.tar.run_step(None)
+
+    assert repr(err_info.value) == ("AssertionError('context must have value "
+                                    "for pypyr.steps.tar',)")
+
+
+def test_tar_throws_if_all_tar_context_missing():
+    """tar context keys must exist."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.tar.run_step(Context({'arbkey': 'arbvalue'}))
+
+    assert repr(err_info.value) == ("KeyNotInContextError(\"pypyr.steps.tar "
+                                    "couldn\'t find tarExtract in context. "
+                                    "This step needs any combination of "
+                                    "tarExtract or tarArchive in context.\",)")
+
+
+def test_tar_throws_if_tar_context_wrong_type():
+    """tar context keys must exist."""
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        pypyr.steps.tar.run_step(
+            Context({'tarExtract': 'it shouldnt be a string'}))
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"pypyr.steps.tar found tarExtract in "
+        "context, but it's not a <class 'dict'>. "
+        "This step needs any combination of "
+        "tarExtract or tarArchive in context.\",)")
+
+
+def test_tar_throws_if_tar_context_no_value():
+    """tar context keys must exist."""
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        pypyr.steps.tar.run_step(
+            Context({'tarExtract': None,
+                     'tarArchive': None}))
+
+    assert repr(err_info.value) == (
+        "KeyInContextHasNoValueError(\"pypyr.steps.tar found tarExtract in "
+        "context but it doesn't have a value. "
+        "This step needs any combination of "
+        "tarExtract or tarArchive in context.\",)")
+
+
+def test_tar_only_calls_extract():
+    """Only calls extract if only extract specified."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarExtract': {
+            'key2': 'ARB_GET_ME1',
+            'key4': 'ARB_GET_ME2'
+        }
+    })
+
+    with patch.multiple('pypyr.steps.tar',
+                        tar_archive=DEFAULT,
+                        tar_extract=DEFAULT
+                        ) as mock_tar:
+        pypyr.steps.tar.run_step(context)
+
+    mock_tar['tar_extract'].assert_called_once()
+    mock_tar['tar_archive'].assert_not_called()
+
+
+def test_tar_only_calls_archive():
+    """Only calls archive if only archive specified."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarArchive': {
+            'key2': 'ARB_GET_ME1',
+            'key4': 'ARB_GET_ME2'
+        }
+    })
+
+    with patch.multiple('pypyr.steps.tar',
+                        tar_archive=DEFAULT,
+                        tar_extract=DEFAULT
+                        ) as mock_tar:
+        pypyr.steps.tar.run_step(context)
+
+    mock_tar['tar_extract'].assert_not_called()
+    mock_tar['tar_archive'].assert_called_once()
+
+
+def test_tar_calls_archive_and_extract():
+    """Calls both extract and archive when both specified."""
+    context = Context({
+        'key2': 'value2',
+        'key1': 'value1',
+        'key3': 'value3',
+        'tarArchive': {
+            'key2': 'ARB_GET_ME1',
+            'key4': 'ARB_GET_ME2'
+        },
+        'tarExtract': {
+            'key2': 'ARB_GET_ME1',
+            'key4': 'ARB_GET_ME2'
+        }
+    })
+
+    with patch.multiple('pypyr.steps.tar',
+                        tar_archive=DEFAULT,
+                        tar_extract=DEFAULT
+                        ) as mock_tar:
+        pypyr.steps.tar.run_step(context)
+
+    mock_tar['tar_extract'].assert_called_once()
+    mock_tar['tar_archive'].assert_called_once()
+
+
+# ------------------------- tar base   ---------------------------------------#
+#
+# ------------------------- tar extract---------------------------------------#
+
+def test_tar_extract_one_pass():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarExtract': {
+            './blah.tar.xz': 'path/to/dir'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_extract(context)
+
+    mock_tarfile.assert_called_once_with('./blah.tar.xz', 'r:*')
+    (mock_tarfile.return_value.
+     __enter__().extractall.assert_called_once_with('path/to/dir'))
+
+
+def test_tar_extract_one_pass_uncompressed():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'tarFormat': '',
+        'tarExtract': {
+            './blah.tar.xz': 'path/to/dir'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_extract(context)
+
+    mock_tarfile.assert_called_once_with('./blah.tar.xz', 'r:')
+    (mock_tarfile.return_value.
+     __enter__().extractall.assert_called_once_with('path/to/dir'))
+
+
+def test_tar_extract_one_with_interpolation():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarExtract': {
+            './{key3}.tar.xz': 'path/{key2}/dir'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_extract(context)
+
+    mock_tarfile.assert_called_once_with('./value3.tar.xz', 'r:*')
+    (mock_tarfile.return_value.
+     __enter__().extractall.assert_called_once_with('path/value2/dir'))
+
+
+def test_tar_extract_pass():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarExtract': {
+            './blah.tar.xz': 'path/to/dir',
+            '/tra/la/la.tar.xz': '.'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_extract(context)
+
+    assert mock_tarfile.call_count == 2
+    mock_tarfile.assert_any_call('./blah.tar.xz', 'r:*')
+    mock_tarfile.assert_any_call('/tra/la/la.tar.xz', 'r:*')
+    (mock_tarfile.return_value.
+     __enter__().extractall.call_count == 2)
+    (mock_tarfile.return_value.
+     __enter__().extractall.assert_any_call('path/to/dir'))
+    (mock_tarfile.return_value.
+     __enter__().extractall.assert_any_call('.'))
+
+# ------------------------- tar extract---------------------------------------#
+
+# ------------------------- tar archive---------------------------------------#
+
+
+def test_tar_archive_one_pass():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarArchive': {
+            'path/to/dir': './blah.tar.xz'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_archive(context)
+
+    mock_tarfile.assert_called_once_with('./blah.tar.xz', 'w:xz')
+    (mock_tarfile.return_value.
+     __enter__().add.assert_called_once_with('path/to/dir'))
+
+
+def test_tar_archive_one_pass_with_interpolation():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarArchive': {
+            '{key2}/to/dir': './blah.tar.{key1}'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_archive(context)
+
+    mock_tarfile.assert_called_once_with('./blah.tar.value1', 'w:xz')
+    (mock_tarfile.return_value.
+     __enter__().add.assert_called_once_with('value2/to/dir'))
+
+
+def test_tar_archive_one_pass_without_compression():
+    """tar extract success case without compression."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'tarFormat': '',
+        'tarArchive': {
+            'path/to/dir': './blah.tar.xz'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_archive(context)
+
+    mock_tarfile.assert_called_once_with('./blah.tar.xz', 'w:')
+    (mock_tarfile.return_value.
+     __enter__().add.assert_called_once_with('path/to/dir'))
+
+
+def test_tar_archive_one_pass_with_gz():
+    """tar extract success case with gz"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'tarFormat': 'gz',
+        'tarArchive': {
+            'path/to/dir': './blah.tar.gz'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_archive(context)
+
+    mock_tarfile.assert_called_once_with('./blah.tar.gz', 'w:gz')
+    (mock_tarfile.return_value.
+     __enter__().add.assert_called_once_with('path/to/dir'))
+
+
+def test_tar_archive_pass():
+    """tar extract success case"""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'tarArchive': {
+            'path/to/dir': './blah.tar.xz',
+            '.': '/tra/la/la.tar.xz'
+        }
+    })
+
+    with patch('tarfile.open') as mock_tarfile:
+        pypyr.steps.tar.tar_archive(context)
+
+    assert mock_tarfile.call_count == 2
+    mock_tarfile.assert_any_call('./blah.tar.xz', 'w:xz')
+    mock_tarfile.assert_any_call('/tra/la/la.tar.xz', 'w:xz')
+    (mock_tarfile.return_value.
+     __enter__().add.call_count == 2)
+    (mock_tarfile.return_value.
+     __enter__().add.assert_any_call('path/to/dir'))
+    (mock_tarfile.return_value.
+     __enter__().add.assert_any_call('.'))
+
+# ------------------------- tar archive --------------------------------------#

--- a/tests/unit/pypyr/steps/tar_test.py
+++ b/tests/unit/pypyr/steps/tar_test.py
@@ -61,7 +61,7 @@ def test_tar_throws_if_tar_context_wrong_type():
 
     assert repr(err_info.value) == (
         "KeyInContextHasNoValueError(\"pypyr.steps.tar found tarExtract in "
-        "context, but it's not a <class 'dict'>. "
+        "context, but it's not a <class 'list'>. "
         "This step needs any combination of "
         "tarExtract or tarArchive in context.\",)")
 
@@ -86,10 +86,12 @@ def test_tar_only_calls_extract():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarExtract': {
-            'key2': 'ARB_GET_ME1',
-            'key4': 'ARB_GET_ME2'
-        }
+        'tarExtract': [
+            {'in': 'key2',
+             'out': 'ARB_GET_ME1'},
+            {'in': 'key4',
+             'out': 'ARB_GET_ME2'}
+        ]
     })
 
     with patch.multiple('pypyr.steps.tar',
@@ -108,10 +110,12 @@ def test_tar_only_calls_archive():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarArchive': {
-            'key2': 'ARB_GET_ME1',
-            'key4': 'ARB_GET_ME2'
-        }
+        'tarArchive': [
+            {'in': 'key2',
+             'out': 'ARB_GET_ME1'},
+            {'in': 'key4',
+             'out': 'ARB_GET_ME2'}
+        ]
     })
 
     with patch.multiple('pypyr.steps.tar',
@@ -130,14 +134,18 @@ def test_tar_calls_archive_and_extract():
         'key2': 'value2',
         'key1': 'value1',
         'key3': 'value3',
-        'tarArchive': {
-            'key2': 'ARB_GET_ME1',
-            'key4': 'ARB_GET_ME2'
-        },
-        'tarExtract': {
-            'key2': 'ARB_GET_ME1',
-            'key4': 'ARB_GET_ME2'
-        }
+        'tarArchive': [
+            {'in': 'key2',
+             'out': 'ARB_GET_ME1'},
+            {'in': 'key4',
+             'out': 'ARB_GET_ME2'}
+        ],
+        'tarExtract': [
+            {'in': 'key2',
+             'out': 'ARB_GET_ME1'},
+            {'in': 'key4',
+             'out': 'ARB_GET_ME2'}
+        ]
     })
 
     with patch.multiple('pypyr.steps.tar',
@@ -160,9 +168,10 @@ def test_tar_extract_one_pass():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarExtract': {
-            './blah.tar.xz': 'path/to/dir'
-        }
+        'tarExtract': [
+            {'in': './blah.tar.xz',
+             'out': 'path/to/dir'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -179,9 +188,10 @@ def test_tar_extract_one_pass_uncompressed():
         'key1': 'value1',
         'key2': 'value2',
         'tarFormat': '',
-        'tarExtract': {
-            './blah.tar.xz': 'path/to/dir'
-        }
+        'tarExtract': [
+            {'in': './blah.tar.xz',
+             'out': 'path/to/dir'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -198,9 +208,10 @@ def test_tar_extract_one_with_interpolation():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarExtract': {
-            './{key3}.tar.xz': 'path/{key2}/dir'
-        }
+        'tarExtract': [
+            {'in': './{key3}.tar.xz',
+             'out': 'path/{key2}/dir'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -217,10 +228,12 @@ def test_tar_extract_pass():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarExtract': {
-            './blah.tar.xz': 'path/to/dir',
-            '/tra/la/la.tar.xz': '.'
-        }
+        'tarExtract': [
+            {'in': './blah.tar.xz',
+             'out': 'path/to/dir'},
+            {'in': '/tra/la/la.tar.xz',
+             'out': '.'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -247,9 +260,10 @@ def test_tar_archive_one_pass():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarArchive': {
-            'path/to/dir': './blah.tar.xz'
-        }
+        'tarArchive': [
+            {'in': 'path/to/dir',
+             'out': './blah.tar.xz'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -266,9 +280,10 @@ def test_tar_archive_one_pass_with_interpolation():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarArchive': {
-            '{key2}/to/dir': './blah.tar.{key1}'
-        }
+        'tarArchive': [
+            {'in': '{key2}/to/dir',
+             'out': './blah.tar.{key1}'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -285,9 +300,10 @@ def test_tar_archive_one_pass_without_compression():
         'key1': 'value1',
         'key2': 'value2',
         'tarFormat': '',
-        'tarArchive': {
-            'path/to/dir': './blah.tar.xz'
-        }
+        'tarArchive': [
+            {'in': 'path/to/dir',
+             'out': './blah.tar.xz'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -304,9 +320,10 @@ def test_tar_archive_one_pass_with_gz():
         'key1': 'value1',
         'key2': 'value2',
         'tarFormat': 'gz',
-        'tarArchive': {
-            'path/to/dir': './blah.tar.gz'
-        }
+        'tarArchive': [
+            {'in': 'path/to/dir',
+             'out': './blah.tar.gz'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:
@@ -323,10 +340,12 @@ def test_tar_archive_pass():
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3',
-        'tarArchive': {
-            'path/to/dir': './blah.tar.xz',
-            '.': '/tra/la/la.tar.xz'
-        }
+        'tarArchive': [
+            {'in': 'path/to/dir',
+             'out': './blah.tar.xz'},
+            {'in': '.',
+             'out': '/tra/la/la.tar.xz'}
+        ]
     })
 
     with patch('tarfile.open') as mock_tarfile:

--- a/tests/unit/pypyr/stepsrunner_test.py
+++ b/tests/unit/pypyr/stepsrunner_test.py
@@ -1,0 +1,123 @@
+"""stepsrunner.py unit tests."""
+from pypyr.context import Context
+import pypyr.stepsrunner
+import pytest
+from unittest.mock import patch
+
+# ------------------------- test context--------------------------------------#
+
+
+def get_test_context():
+    """Return a pypyr context for testing."""
+    return Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'key4': [
+            {'k4lk1': 'value4',
+             'k4lk2': 'value5'},
+            {'k4lk1': 'value6',
+             'k4lk2': 'value7'}
+        ],
+        'key5': False,
+        'key6': True,
+        'key7': 77
+    })
+
+# ------------------------- test context--------------------------------------#
+
+# ------------------------- step mocks ---------------------------------------#
+
+
+def mock_run_step(context):
+    """Arbitrary mock function to execute instead of run_step"""
+    context['test_run_step'] = 'this was set in step'
+
+
+def mock_run_step_empty_context(context):
+    """Clear the context in the step."""
+    context.clear()
+
+
+def mock_run_step_none_context(context):
+    """None the context in the step"""
+    # ignore the context is not used flake8 warning
+    context = None  # noqa: F841
+# ------------------------- step mocks ---------------------------------------#
+
+
+# ------------------------- run_pipeline_step---------------------------------#
+@patch('pypyr.moduleloader.get_module')
+def test_run_pipeline_step_pass(mocked_moduleloader):
+    """run_pipeline_step test pass."""
+    pypyr.stepsrunner.run_pipeline_step('mocked.step', get_test_context())
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    mocked_moduleloader.return_value.run_step.assert_called_once_with(
+        {'key1': 'value1',
+         'key2': 'value2',
+         'key3': 'value3',
+         'key4': [
+             {'k4lk1': 'value4', 'k4lk2': 'value5'},
+             {'k4lk1': 'value6', 'k4lk2': 'value7'}],
+         'key5': False,
+         'key6': True,
+         'key7': 77})
+
+
+@patch('pypyr.moduleloader.get_module', return_value=3)
+def test_run_pipeline_step_no_run_step(mocked_moduleloader):
+    """run_pipeline_step fails if no run_step on imported module."""
+    with pytest.raises(AttributeError) as err_info:
+        pypyr.stepsrunner.run_pipeline_step('mocked.step', get_test_context)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+
+    assert repr(err_info.value) == (
+        "AttributeError(\"'int' object has no attribute 'run_step'\",)")
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_run_pipeline_step_context_abides(mocked_moduleloader):
+    """Steps mutate context & mutation abides after run_pipeline_step."""
+    mocked_moduleloader.return_value.run_step = mock_run_step
+    context = get_test_context()
+
+    pypyr.stepsrunner.run_pipeline_step('mocked.step', context)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    assert context['test_run_step'] == 'this was set in step'
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_run_pipeline_step_empty_context(mocked_moduleloader):
+    """Empty context in step (i.e count == 0, but not is None)"""
+    mocked_moduleloader.return_value.run_step = mock_run_step_empty_context
+    context = get_test_context()
+
+    pypyr.stepsrunner.run_pipeline_step('mocked.step', context)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    assert len(context) == 0
+    assert context is not None
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_run_pipeline_step_none_context(mocked_moduleloader):
+    """Step rebinding context to None doesn't affect the caller Context."""
+    mocked_moduleloader.return_value.run_step = mock_run_step_none_context
+    context = get_test_context()
+
+    pypyr.stepsrunner.run_pipeline_step('mocked.step', False)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    assert context == {'key1': 'value1',
+                       'key2': 'value2',
+                       'key3': 'value3',
+                       'key4': [
+                           {'k4lk1': 'value4', 'k4lk2': 'value5'},
+                           {'k4lk1': 'value6', 'k4lk2': 'value7'}],
+                       'key5': False,
+                       'key6': True,
+                       'key7': 77}
+# ------------------------- run_pipeline_step---------------------------------#


### PR DESCRIPTION
- KeyNotInContextError and KeyInContextHasNoValueError added. Refactor throughout to use new errs rather than KeyError. 
  - NB: henceforth, Context throws KeyNotInContextError, not KeyError, on __ missing __
- echoMe refactor to deal more sensibly with non-str types
- py.step had unreachable code, removed.
- new steps:
  - tar
  - contextclear
  - contextclearall
- stepsrunner had unreachable code (steps can't re-assign context to None due to python call-by-obj param passing)
- bug fixes for format strings missing f""
- bug fix: complex steps exploded if didn't have the optional "in" context specified.
- 100% test coverage as of now