### PR TITLE
recursive string interpolation for iterable types

### DIFF
--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -167,8 +167,14 @@ class Context(dict):
     def get_formatted(self, key):
         """Returns formatted value for context[key].
 
-        Only valid if context[key] is a type string.
-        Return a string interpolated from the context dictionary.
+        If context[key] is a type string, will just format and return the
+        string.
+        If context[key] is not a string, specifically an iterable type like a
+        dict, list, tuple, set, it will use get_formatted_iterable under the
+        covers to loop through and handle the entire structure contained in
+        context[key].
+
+        Returns a string interpolated from the context dictionary.
 
         If context[key]='Piping {key1} the {key2} wild'
         And context={'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
@@ -182,9 +188,8 @@ class Context(dict):
             Formatted string.
 
         Raises:
-            KeyError: context[key] value contains {somekey} where somekey does
-                      not exist in context dictionary.
-            TypeError: Attempt operation on a non-string type.
+            KeyNotInContextError: context[key] value contains {somekey} where
+                                  somekey does not exist in context dictionary.
         """
         val = self[key]
 
@@ -201,8 +206,8 @@ class Context(dict):
                     f'context[\'{missing_key}\'] doesn\'t exist'
                 ) from err
         else:
-            raise TypeError(f"can only format on strings. {val} is a "
-                            f"{type(val)} instead.")
+            # any sort of complex type will work with get_formatted_iterable.
+            return self.get_formatted_iterable(val)
 
     def get_formatted_iterable(self, obj, memo=None):
         """Recursively loop through obj, formatting as it goes.

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -249,7 +249,6 @@ class Context(dict):
 
         if isinstance(obj, str):
             new = self.get_formatted_string(obj)
-            # return self.get_formatted_string(obj)
         elif isinstance(obj, (bytes, bytearray)):
             new = obj
         elif isinstance(obj, Mapping):

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -1,5 +1,6 @@
 """pypyr context class. Dictionary ahoy."""
 from collections import namedtuple
+from collections.abc import Mapping, Set, Sequence
 from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
 
 ContextItemInfo = namedtuple('ContextItemInfo',
@@ -202,6 +203,70 @@ class Context(dict):
         else:
             raise TypeError(f"can only format on strings. {val} is a "
                             f"{type(val)} instead.")
+
+    def get_formatted_iterable(self, obj, memo=None):
+        """Recursively loop through obj, formatting as it goes.
+
+        Interpolates strings from the context dictionary.
+
+        This is not a full on deepcopy, and it's on purpose not a full on
+        deepcopy. It will handle dict, list, set, tuple for iteration, without
+        any especial cuteness for other types or types not derived from these.
+
+        For lists: if value is a string, format it.
+        For dicts: format key. If value str, format it.
+        For sets/tuples: if type str, format it.
+
+        This is what formatting or interpolating a string means:
+        So where a string like this 'Piping {key1} the {key2} wild'
+        And context={'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
+
+        Then this will return string: "Piping down the valleys wild"
+
+        Args:
+            obj: iterable. Recurse through and format strings found in
+                           dicts, lists, tuples. Does not mutate the input
+                           iterable.
+            memo: dict. Don't use. Used internally on recursion to optimize
+                        recursive loops.
+
+        Returns:
+            Iterable identical in structure to the input iterable.
+        """
+
+        if memo is None:
+            memo = {}
+
+        obj_id = id(obj)
+        already_done = memo.get(obj_id, None)
+        if already_done is not None:
+            return already_done
+
+        if isinstance(obj, str):
+            new = self.get_formatted_string(obj)
+            # return self.get_formatted_string(obj)
+        elif isinstance(obj, (bytes, bytearray)):
+            new = obj
+        elif isinstance(obj, Mapping):
+            # dicts
+            new = obj.__class__()
+            for k, v in obj.items():
+                new[self.get_formatted_string(
+                    k)] = self.get_formatted_iterable(v, memo)
+        elif isinstance(obj, (Sequence, Set)):
+            # list, set, tuple. Bytes and str won't fall into this branch coz
+            # they're expicitly checked further up in the if.
+            new = obj.__class__(self.get_formatted_iterable(v, memo)
+                                for v in obj)
+        else:
+            # int, float, bool, function, et.
+            return obj
+
+        # If is its own copy, don't memoize.
+        if new is not obj:
+            memo[obj_id] = new
+
+        return new
 
     def get_formatted_string(self, input_string):
         """Returns formatted value for input_string.

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.5.2
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -480,6 +480,249 @@ def test_input_string_not_a_string_throw():
     assert repr(err_info.value) == (
         "TypeError(\"can only format on strings. 77 is a <class 'int'> "
         "instead.\",)")
+
+
+def test_get_formatted_iterable_list():
+    """Simple list"""
+    input_obj = ['k1', 'k2', '{ctx3}', True, False, 44]
+
+    context = Context(
+        {'ctx1': 'ctxvalue1', 'ctx2': 'ctxvalue2', 'ctx3': 'ctxvalue3'})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    assert output is not input_obj
+    assert output[0] == 'k1'
+    assert output[1] == 'k2'
+    assert output[2] == 'ctxvalue3'
+    assert output[3]
+    assert not output[4]
+    assert output[5] == 44
+
+
+def test_get_formatted_iterable_tuple():
+    """Simple tuple"""
+    input_obj = ('k1', 'k2', '{ctx3}', True, False, 44)
+
+    context = Context(
+        {'ctx1': 'ctxvalue1', 'ctx2': 'ctxvalue2', 'ctx3': 'ctxvalue3'})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    assert output is not input_obj
+    assert output[0] == 'k1'
+    assert output[1] == 'k2'
+    assert output[2] == 'ctxvalue3'
+    assert output[3]
+    assert not output[4]
+    assert output[5] == 44
+
+
+def test_get_formatted_iterable_set():
+    """Simple set"""
+    input_obj = {'k1', 'k2', '{ctx3}', True, False, 44}
+
+    context = Context(
+        {'ctx1': 'ctxvalue1', 'ctx2': 'ctxvalue2', 'ctx3': 'ctxvalue3'})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    assert output is not input_obj
+    assert len(output) == len(input_obj)
+    diffs = output - input_obj
+    assert len(diffs) == 1
+    assert 'ctxvalue3' in diffs
+
+
+def test_get_formatted_iterable_nested():
+    """Straight deepish copy with no formatting."""
+    # dict containing dict, list, dict-list-dict, tuple, dict-tuple-list
+    input_obj = {'k1': 'v1',
+                 'k2': 'v2',
+                 'k3': 'v3',
+                 'k4': [
+                     1,
+                     2,
+                     '3here',
+                     {'key4.1': 'value4.1',
+                      'key4.2': 'value4.2',
+                      'key4.3': {
+                          '4.3.1': '4.3.1value',
+                          '4.3.2': '4.3.2value'}}
+                 ],
+                 'k5': {'key5.1': 'value5.1', 'key5.2': 'value5.2'},
+                 'k6': ('six6.1', False, [0, 1, 2], 77, 'sixend'),
+                 'k7': 'simple string to close 7'
+                 }
+
+    context = Context(
+        {'ctx1': 'ctxvalue1', 'ctx2': 'ctxvalue2', 'ctx3': 'ctxvalue3'})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    assert output == input_obj
+    assert output is not context
+    # verify this was a deep copy - obj refs has to be different for nested
+    assert id(output['k4']) != id(input_obj['k4'])
+    assert id(output['k4'][3]['key4.3']) != id(input_obj['k4'][3]['key4.3'])
+    assert id(output['k5']) != id(input_obj['k5'])
+    assert id(output['k6']) != id(input_obj['k6'])
+    assert id(output['k6'][2]) != id(input_obj['k6'][2])
+    assert id(output['k7']) == id(input_obj['k7'])
+
+    # and proving the theory: mutating output does not touch input
+    assert output['k4'][1] == 2
+    output['k4'][1] = 88
+    assert input_obj['k4'][1] == 2
+    assert output['k4'][1] == 88
+
+
+def test_get_formatted_iterable_nested_with_formatting():
+    """Straight deepish copy with formatting."""
+    # dict containing dict, list, dict-list-dict, tuple, dict-tuple-list, bytes
+    input_obj = {'k1': 'v1',
+                 'k2': 'v2_{ctx1}',
+                 'k3': bytes('v3{ctx1}', encoding='utf-8'),
+                 'k4': [
+                     1,
+                     2,
+                     '3_{ctx4}here',
+                     {'key4.1': 'value4.1',
+                      '{ctx2}_key4.2': 'value_{ctx3}_4.2',
+                      'key4.3': {
+                          '4.3.1': '4.3.1value',
+                          '4.3.2': '4.3.2_{ctx1}_value'}}
+                 ],
+                 'k5': {'key5.1': 'value5.1', 'key5.2': 'value5.2'},
+                 'k6': ('six6.1', False, [0, 1, 2], 77, 'six_{ctx1}_end'),
+                 'k7': 'simple string to close 7'
+                 }
+
+    context = Context(
+        {'ctx1': 'ctxvalue1',
+         'ctx2': 'ctxvalue2',
+         'ctx3': 'ctxvalue3',
+         'ctx4': 'ctxvalue4'})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    assert output != input_obj
+
+    # verify formatted strings
+    assert input_obj['k2'] == 'v2_{ctx1}'
+    assert output['k2'] == 'v2_ctxvalue1'
+
+    assert input_obj['k3'] == b'v3{ctx1}'
+    assert output['k3'] == b'v3{ctx1}'
+
+    assert input_obj['k4'][2] == '3_{ctx4}here'
+    assert output['k4'][2] == '3_ctxvalue4here'
+
+    assert input_obj['k4'][3]['{ctx2}_key4.2'] == 'value_{ctx3}_4.2'
+    assert output['k4'][3]['ctxvalue2_key4.2'] == 'value_ctxvalue3_4.2'
+
+    assert input_obj['k4'][3]['key4.3']['4.3.2'] == '4.3.2_{ctx1}_value'
+    assert output['k4'][3]['key4.3']['4.3.2'] == '4.3.2_ctxvalue1_value'
+
+    assert input_obj['k6'][4] == 'six_{ctx1}_end'
+    assert output['k6'][4] == 'six_ctxvalue1_end'
+
+    # verify this was a deep copy - obj refs has to be different for nested
+    assert id(output['k4']) != id(input_obj['k4'])
+    assert id(output['k4'][3]['key4.3']) != id(input_obj['k4'][3]['key4.3'])
+    assert id(output['k5']) != id(input_obj['k5'])
+    assert id(output['k6']) != id(input_obj['k6'])
+    assert id(output['k6'][2]) != id(input_obj['k6'][2])
+    # strings are interned in python, so id is the same
+    assert id(output['k7']) == id(input_obj['k7'])
+    output['k7'] = 'mutate 7 on new'
+    assert input_obj['k7'] == 'simple string to close 7'
+    assert output['k7'] == 'mutate 7 on new'
+
+
+def test_get_formatted_iterable_with_memo():
+    """Straight deepish copy with formatting."""
+
+    arb_dict = {'key4.1': 'value4.1',
+                '{ctx2}_key4.2': 'value_{ctx3}_4.2',
+                'key4.3': {
+                    '4.3.1': '4.3.1value',
+                    '4.3.2': '4.3.2_{ctx1}_value'}}
+
+    arb_list = [0, 1, 2]
+
+    arb_string = 'arb string'
+
+    arb_string_with_formatting = 'a {ctx1} string'
+
+    input_obj = {'k1': arb_string,
+                 'k2': 'v2_{ctx1}',
+                 'k3': arb_list,
+                 'k4': [
+                     arb_dict,
+                     2,
+                     '3_{ctx4}here',
+                     arb_dict
+                 ],
+                 'k5': {'key5.1': arb_string,
+                        'key5.2': arb_string_with_formatting},
+                 'k6': ('six6.1', False, arb_list, 77, 'six_{ctx1}_end'),
+                 'k7': 'simple string to close 7',
+                 'k8': arb_string_with_formatting
+                 }
+
+    context = Context(
+        {'ctx1': 'ctxvalue1',
+         'ctx2': 'ctxvalue2',
+         'ctx3': 'ctxvalue3',
+         'ctx4': 'ctxvalue4'})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    # same obj re-used at different levels of the hierarchy
+    assert id(input_obj['k3']) == id(input_obj['k6'][2])
+    assert id(input_obj['k4'][0]) == id(input_obj['k4'][3])
+
+    assert output != input_obj
+
+    # verify formatted strings
+    assert input_obj['k2'] == 'v2_{ctx1}'
+    assert output['k2'] == 'v2_ctxvalue1'
+
+    assert input_obj['k4'][2] == '3_{ctx4}here'
+    assert output['k4'][2] == '3_ctxvalue4here'
+
+    assert input_obj['k4'][3]['{ctx2}_key4.2'] == 'value_{ctx3}_4.2'
+    assert output['k4'][3]['ctxvalue2_key4.2'] == 'value_ctxvalue3_4.2'
+
+    assert input_obj['k4'][3]['key4.3']['4.3.2'] == '4.3.2_{ctx1}_value'
+    assert output['k4'][3]['key4.3']['4.3.2'] == '4.3.2_ctxvalue1_value'
+
+    assert input_obj['k6'][4] == 'six_{ctx1}_end'
+    assert output['k6'][4] == 'six_ctxvalue1_end'
+
+    # verify this was a deep copy - obj refs has to be different for nested
+    assert id(output['k4']) != id(input_obj['k4'])
+    assert id(output['k4'][3]['key4.3']) != id(input_obj['k4'][3]['key4.3'])
+    assert id(output['k5']) != id(input_obj['k5'])
+    assert id(output['k6']) != id(input_obj['k6'])
+    assert id(output['k6'][2]) != id(input_obj['k6'][2])
+    assert id(output['k7']) == id(input_obj['k7'])
+    output['k7'] = 'mutate 7 on new'
+    assert input_obj['k7'] == 'simple string to close 7'
+    assert input_obj['k8'] == arb_string_with_formatting
+    assert output['k8'] == 'a ctxvalue1 string'
+
+    # memo did object re-use so same obj re-used at different levels of the
+    # hierarchy
+    assert id(output['k3']) == id(output['k6'][2])
+    assert id(output['k4'][0]) == id(output['k4'][3])
+    assert output['k5']['key5.1'] == input_obj['k5']['key5.1'] == arb_string
+    assert id(output['k5']['key5.1']) == id(
+        input_obj['k5']['key5.1']) == id(arb_string)
+    assert id(output['k8']) == id(output['k5']['key5.2'])
+    assert id(output['k8']) != id(arb_string_with_formatting)
+
 # ------------------- formats ------------------------------------------------#
 
 # ------------------- key info -----------------------------------------------#

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -440,15 +440,18 @@ def test_tag_not_in_context_should_throw():
         "context['key2'] doesn't exist\",)")
 
 
-def test_context_item_not_a_string_should_throw():
-    with pytest.raises(TypeError) as err_info:
-        context = Context({'key1': 'value1'})
-        context['input_string'] = 77
-        context.get_formatted('input_string')
+def test_context_item_not_a_string_should_return_as_is():
+    context = Context({'key1': 'value1'})
+    context['input_string'] = 77
+    val = context.get_formatted('input_string')
+    assert val == 77
 
-    assert repr(err_info.value) == (
-        "TypeError(\"can only format on strings. 77 is a <class 'int'> "
-        "instead.\",)")
+
+def test_context_item_list_should_iterate():
+    context = Context({'key1': 'value1'})
+    context['input_string'] = ['string1', '{key1}', 'string3']
+    val = context.get_formatted('input_string')
+    assert val == ['string1', 'value1', 'string3']
 
 
 def test_input_string_interpolate_works():


### PR DESCRIPTION
- Add recursive string interpolation so can format iterable and nested iterable types
- get_formatted will now, instead of raising typerror on non-str, use the recursive function to parse types other than str
- version bump for patch release