### PR TITLE
wait_until_true decorator

### DIFF
--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -313,6 +313,33 @@ class Context(dict):
             raise TypeError(f"can only format on strings. {input_string} is a "
                             f"{type(input_string)} instead.")
 
+    def get_formatted_as_type(self, value, default=None, out_type=str):
+        """Returns formatted value for input value, returns as out_type.
+
+        Caveat emptor: if out_type is bool, return will always be True.
+
+        Args:
+            value: the value to format
+            default: if value is None, set to this
+            out_type: cast return as this type
+
+        Returns:
+            Formatted value of type out_type
+        """
+        if value is None:
+            value = default
+
+        if isinstance(value, str):
+            result = self.get_formatted_string(value)
+
+            # get_formatted_string result is already a string
+            if out_type is str:
+                return result
+            else:
+                return out_type(result)
+        else:
+            return value
+
     def get_processed_string(self, input_string):
         """Runs token substitution on input_string against context.
 

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -316,7 +316,9 @@ class Context(dict):
     def get_formatted_as_type(self, value, default=None, out_type=str):
         """Returns formatted value for input value, returns as out_type.
 
-        Caveat emptor: if out_type is bool, return will always be True.
+        Caveat emptor: if out_type is bool and value a string,
+        return will always be True. Be sure to pass in a bool and have out_type
+        also bool if working with booleans.
 
         Args:
             value: the value to format

--- a/pypyr/utils/poll.py
+++ b/pypyr/utils/poll.py
@@ -1,0 +1,42 @@
+"""Utility functions for polling."""
+import time
+import logging
+
+# pypyr logger means the log level will be set correctly and output formatted.
+logger = logging.getLogger(__name__)
+
+
+def wait_until_true(interval, max_attempts):
+    """Decorator that executes a function until it returns True.
+
+    Executes wrapped function at every number of seconds specified by interval,
+    until wrapped function either returns True or max_attempts are exhausted,
+    whichever comes 1st.
+
+    Args:
+        interval: In seconds. How long to wait between executing the wrapped
+                  function.
+        max_attempts: int. Execute wrapped function up to this limit.
+
+    Returns:
+        Bool. True if wrapped function returned True. False if reached
+              max_attempts without the wrapped function ever returning True.
+    """
+    def decorator(f):
+        logger.debug("started")
+
+        def sleep_looper(*args, **kwargs):
+            logger.debug(f"Looping every {interval} seconds for "
+                         f"{max_attempts} attempts")
+            for i in range(1, max_attempts + 1):
+                result = f(*args, **kwargs)
+                if result:
+                    logger.debug(f"iteration {i}. Desired state reached.")
+                    return True
+                logger.debug(f"iteration {i}. Still waiting. . .")
+                time.sleep(interval)
+            return False
+        return sleep_looper
+
+    logger.debug("done")
+    return decorator

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.5'
+__version__ = '0.5.6'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.5
+current_version = 0.5.6
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -831,6 +831,72 @@ def test_iter_formatted():
     assert output[3] == "this ctxvalue4 is line 4"
 
 
+def test_get_formatted_as_type_bool_no_subst():
+    """get_formatted_as_type returns int no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type('false', out_type=bool)
+
+    assert isinstance(result, bool)
+    # bools always true
+    assert result
+
+
+def test_get_formatted_as_type_int_no_subst():
+    """get_formatted_as_type returns int no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type('10', out_type=int)
+
+    assert isinstance(result, int)
+    assert result == 10
+
+
+def test_get_formatted_as_type_int_with_subst():
+    """get_formatted_as_type returns int no formatting"""
+    context = Context({'k1': 10})
+    result = context.get_formatted_as_type('{k1}', out_type=int)
+
+    assert isinstance(result, int)
+    assert result == 10
+
+
+def test_get_formatted_as_type_float_no_subst():
+    """get_formatted_as_type returns float no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type('10.1', out_type=float)
+
+    assert isinstance(result, float)
+    assert result == 10.1
+
+
+def test_get_formatted_as_type_default_no_subst():
+    """get_formatted_as_type returns default no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type(None, default=10, out_type=int)
+
+    assert isinstance(result, int)
+    assert result == 10
+
+
+def test_get_formatted_as_type_default_with_subst():
+    """get_formatted_as_type returns default with formatting"""
+    context = Context({'k1': 10})
+    result = context.get_formatted_as_type(
+        None, default='{k1}', out_type=int)
+
+    assert isinstance(result, int)
+    assert result == 10
+
+
+def test_get_formatted_as_type_default_with_subst_str():
+    """get_formatted_as_type returns default with formatting"""
+    context = Context({'k1': 10})
+    result = context.get_formatted_as_type(
+        None, default='xx{k1}xx')
+
+    assert isinstance(result, str)
+    assert result == 'xx10xx'
+
+
 def test_get_processed_string_no_interpolation():
     """get_processed_string on plain string returns plain."""
     context = Context(

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -831,13 +831,31 @@ def test_iter_formatted():
     assert output[3] == "this ctxvalue4 is line 4"
 
 
-def test_get_formatted_as_type_bool_no_subst():
-    """get_formatted_as_type returns int no formatting"""
+def test_get_formatted_as_type_string_to_bool_no_subst():
+    """get_formatted_as_type returns bool no formatting"""
     context = Context()
     result = context.get_formatted_as_type('false', out_type=bool)
 
     assert isinstance(result, bool)
     # bools always true
+    assert result
+
+
+def test_get_formatted_as_type_bool_false_no_subst():
+    """get_formatted_as_type returns bool no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type(False, out_type=bool)
+
+    assert isinstance(result, bool)
+    assert not result
+
+
+def test_get_formatted_as_type_bool_true_no_subst():
+    """get_formatted_as_type returns bool no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type(None, True, out_type=bool)
+
+    assert isinstance(result, bool)
     assert result
 
 

--- a/tests/unit/pypyr/utils/poll_test.py
+++ b/tests/unit/pypyr/utils/poll_test.py
@@ -1,0 +1,90 @@
+"""poll.py unit tests."""
+import pypyr.utils.poll as poll
+from unittest.mock import MagicMock
+
+
+# ----------------- wait_until_true -------------------------------------------
+def test_wait_until_true_with_static_decorator():
+    """wait_until_true with static decorator"""
+    mock = MagicMock()
+    mock.side_effect = [
+        'test string 1',
+        'test string 2',
+        'test string 3',
+        'expected value',
+        'test string 5'
+    ]
+
+    @poll.wait_until_true(interval=0.1, max_attempts=10)
+    def decorate_me(arg1, arg2):
+        """Test static decorator syntax"""
+        assert arg1 == 'v1'
+        assert arg2 == 'v2'
+        if mock(arg1) == 'expected value':
+            return True
+        else:
+            return False
+
+    assert decorate_me('v1', 'v2')
+    assert mock.call_count == 4
+    mock.assert_called_with('v1')
+
+
+def test_wait_until_true_invoke_inline():
+    """wait_until_true with dynamic invocation."""
+    mock = MagicMock()
+    mock.side_effect = [
+        'test string 1',
+        'test string 2',
+        'test string 3',
+        'expected value',
+        'test string 5'
+    ]
+
+    def decorate_me(arg1, arg2):
+        """Test static decorator syntax"""
+        assert arg1 == 'v1'
+        assert arg2 == 'v2'
+        if mock(arg1) == 'expected value':
+            return True
+        else:
+            return False
+
+    assert poll.wait_until_true(interval=0.1, max_attempts=10)(
+        decorate_me)('v1', 'v2')
+    assert mock.call_count == 4
+    mock.assert_called_with('v1')
+
+
+def test_wait_until_true_with_timeout():
+    """wait_until_true with dynamic invocation, exhaust wait attempts."""
+    mock = MagicMock()
+    mock.side_effect = [
+        'test string 1',
+        'test string 2',
+        'test string 3',
+        'test string 4',
+        'test string 5',
+        'test string 6',
+        'test string 7',
+        'test string 8',
+        'test string 9',
+        'test string 10',
+        'test string 11',
+    ]
+
+    def decorate_me(arg1, arg2):
+        """Test static decorator syntax"""
+        assert arg1 == 'v1'
+        assert arg2 == 'v2'
+        if mock(arg1) == 'expected value':
+            return True
+        else:
+            return False
+
+    assert not poll.wait_until_true(interval=0.1, max_attempts=10)(
+        decorate_me)('v1', 'v2')
+    assert mock.call_count == 10
+    mock.assert_called_with('v1')
+
+# ----------------- wait_until_true -------------------------------------------

--- a/tests/unit/pypyr/utils/poll_test.py
+++ b/tests/unit/pypyr/utils/poll_test.py
@@ -15,7 +15,7 @@ def test_wait_until_true_with_static_decorator():
         'test string 5'
     ]
 
-    @poll.wait_until_true(interval=0.1, max_attempts=10)
+    @poll.wait_until_true(interval=0.01, max_attempts=10)
     def decorate_me(arg1, arg2):
         """Test static decorator syntax"""
         assert arg1 == 'v1'
@@ -50,7 +50,7 @@ def test_wait_until_true_invoke_inline():
         else:
             return False
 
-    assert poll.wait_until_true(interval=0.1, max_attempts=10)(
+    assert poll.wait_until_true(interval=0.01, max_attempts=10)(
         decorate_me)('v1', 'v2')
     assert mock.call_count == 4
     mock.assert_called_with('v1')
@@ -82,7 +82,7 @@ def test_wait_until_true_with_timeout():
         else:
             return False
 
-    assert not poll.wait_until_true(interval=0.1, max_attempts=10)(
+    assert not poll.wait_until_true(interval=0.01, max_attempts=10)(
         decorate_me)('v1', 'v2')
     assert mock.call_count == 10
     mock.assert_called_with('v1')

--- a/tests/unit/pypyr/utils/poll_test.py
+++ b/tests/unit/pypyr/utils/poll_test.py
@@ -1,10 +1,11 @@
 """poll.py unit tests."""
 import pypyr.utils.poll as poll
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 # ----------------- wait_until_true -------------------------------------------
-def test_wait_until_true_with_static_decorator():
+@patch('time.sleep')
+def test_wait_until_true_with_static_decorator(mock_time_sleep):
     """wait_until_true with static decorator"""
     mock = MagicMock()
     mock.side_effect = [
@@ -28,9 +29,12 @@ def test_wait_until_true_with_static_decorator():
     assert decorate_me('v1', 'v2')
     assert mock.call_count == 4
     mock.assert_called_with('v1')
+    assert mock_time_sleep.call_count == 3
+    mock_time_sleep.assert_called_with(0.01)
 
 
-def test_wait_until_true_invoke_inline():
+@patch('time.sleep')
+def test_wait_until_true_invoke_inline(mock_time_sleep):
     """wait_until_true with dynamic invocation."""
     mock = MagicMock()
     mock.side_effect = [
@@ -54,9 +58,12 @@ def test_wait_until_true_invoke_inline():
         decorate_me)('v1', 'v2')
     assert mock.call_count == 4
     mock.assert_called_with('v1')
+    assert mock_time_sleep.call_count == 3
+    mock_time_sleep.assert_called_with(0.01)
 
 
-def test_wait_until_true_with_timeout():
+@patch('time.sleep')
+def test_wait_until_true_with_timeout(mock_time_sleep):
     """wait_until_true with dynamic invocation, exhaust wait attempts."""
     mock = MagicMock()
     mock.side_effect = [
@@ -86,5 +93,7 @@ def test_wait_until_true_with_timeout():
         decorate_me)('v1', 'v2')
     assert mock.call_count == 10
     mock.assert_called_with('v1')
+    assert mock_time_sleep.call_count == 10
+    mock_time_sleep.assert_called_with(0.01)
 
 # ----------------- wait_until_true -------------------------------------------


### PR DESCRIPTION
- add pypyr utils _wait_until_true_. This allows you to decorate any given function with `@wait_until_true(interval, max_attempts)` and it will execute that function on the specified intervals until max attempts reached, until the function returns true.
- add context get_formatted_as_type, to format string values AND return as a certain type that's not necessarily a string.