### PR TITLE
get_formatted_as_type does bools

### DIFF
--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -317,8 +317,8 @@ class Context(dict):
         """Returns formatted value for input value, returns as out_type.
 
         Caveat emptor: if out_type is bool and value a string,
-        return will always be True. Be sure to pass in a bool and have out_type
-        also bool if working with booleans.
+        return will be True if str is 'True'. It will be False for all other
+        cases.
 
         Args:
             value: the value to format
@@ -334,9 +334,14 @@ class Context(dict):
         if isinstance(value, str):
             result = self.get_formatted_string(value)
 
-            # get_formatted_string result is already a string
             if out_type is str:
+                # get_formatted_string result is already a string
                 return result
+            elif out_type is bool:
+                # casting a str to bool is always True, hence special case. If
+                # the str value is 'False'/'false', presumably user can
+                # reasonably expect a bool False response.
+                return result == 'True'
             else:
                 return out_type(result)
         else:

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.6
+current_version = 0.5.7
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -834,10 +834,18 @@ def test_iter_formatted():
 def test_get_formatted_as_type_string_to_bool_no_subst():
     """get_formatted_as_type returns bool no formatting"""
     context = Context()
-    result = context.get_formatted_as_type('false', out_type=bool)
+    result = context.get_formatted_as_type('False', out_type=bool)
 
     assert isinstance(result, bool)
-    # bools always true
+    assert not result
+
+
+def test_get_formatted_as_type_string_to_true_bool_no_subst():
+    """get_formatted_as_type returns bool no formatting"""
+    context = Context()
+    result = context.get_formatted_as_type('True', out_type=bool)
+
+    assert isinstance(result, bool)
     assert result
 
 
@@ -854,6 +862,24 @@ def test_get_formatted_as_type_bool_true_no_subst():
     """get_formatted_as_type returns bool no formatting"""
     context = Context()
     result = context.get_formatted_as_type(None, True, out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
+def test_get_formatted_as_type_bool_false_with_subst():
+    """get_formatted_as_type returns bool with formatting"""
+    context = Context({'k1': False})
+    result = context.get_formatted_as_type(None, '{k1}', out_type=bool)
+
+    assert isinstance(result, bool)
+    assert not result
+
+
+def test_get_formatted_as_type_bool_true_with_subst():
+    """get_formatted_as_type returns bool with formatting"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type(None, '{k1}', out_type=bool)
 
     assert isinstance(result, bool)
     assert result


### PR DESCRIPTION
- get_formatted_as_type previously would return True for all str -> bool conversions. Now 'True' will return `True`, and all other strings return `False` when casting to bool.
- version bump