### PR TITLE
Failure handler initializes empty pypyr Context

### DIFF
--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -125,7 +125,7 @@ def main(pipeline_name, pipeline_context_input, working_dir, log_level):
             # before assignment err.
             parsed_context
         except NameError:
-            parsed_context = {}
+            parsed_context = pypyr.context.Context()
 
         # failure_step_group will log but swallow any errors
         pypyr.stepsrunner.run_failure_step_group(

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.9'
+__version__ = '0.5.10'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.9
+current_version = 0.5.10
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -152,15 +152,14 @@ def test_get_main_pass(mocked_work_dir,
 
 
 @patch('pypyr.stepsrunner.run_step_group')
-@patch('pypyr.pipelinerunner.get_parsed_context',
-       return_value='parsed context')
+@patch('pypyr.pipelinerunner.get_parsed_context')
 @patch('pypyr.pipelinerunner.get_pipeline_definition', return_value='pipe def')
 @patch('pypyr.moduleloader.set_working_directory')
 def test_get_main_parse_context_error(mocked_work_dir,
                                       mocked_get_pipe_def,
                                       mocked_get_parsed_context,
                                       mocked_run_step_group):
-    """main runs on_failure with {} dict if context parse fails."""
+    """main runs on_failure with empty Context if context parse fails."""
     mocked_get_parsed_context.side_effect = ContextError
 
     with pytest.raises(ContextError):
@@ -177,11 +176,16 @@ def test_get_main_parse_context_error(mocked_work_dir,
         context_in_string='arb context input')
 
     # No called steps, just on_failure since err on parse context already
-    expected_run_step_groups = [call(context={},
+    expected_run_step_groups = [call(context=Context(),
                                      pipeline_definition='pipe def',
                                      step_group_name='on_failure')]
 
     mocked_run_step_group.assert_has_calls(expected_run_step_groups)
+
+    print(mocked_run_step_group.call_args)
+    call_args_tuple = mocked_run_step_group.call_args
+    args, kwargs = call_args_tuple
+    assert isinstance(kwargs['context'], Context)
 
 
 @patch('pypyr.stepsrunner.run_step_group')

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -182,7 +182,6 @@ def test_get_main_parse_context_error(mocked_work_dir,
 
     mocked_run_step_group.assert_has_calls(expected_run_step_groups)
 
-    print(mocked_run_step_group.call_args)
     call_args_tuple = mocked_run_step_group.call_args
     args, kwargs = call_args_tuple
     assert isinstance(kwargs['context'], Context)


### PR DESCRIPTION
- If pypyr context can't create, create an empty pypyr Context to allow failure handler steps access to the pypyr Context even if empty - steps reasonably can expect a Context-like type input
- version bump