### PR TITLE
tar archive only the last dir

### DIFF
--- a/pypyr/steps/tar.py
+++ b/pypyr/steps/tar.py
@@ -126,7 +126,7 @@ def tar_archive(context):
         with tarfile.open(destination, mode) as archive_me:
             logger.debug(f"Archiving '{source}' to '{destination}'")
 
-            archive_me.add(source)
+            archive_me.add(source, arcname='.')
             logger.info(f"Archived '{source}' to '{destination}'")
 
     logger.debug("end")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.10'
+__version__ = '0.5.11'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.10
+current_version = 0.5.11
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/steps/tar_test.py
+++ b/tests/unit/pypyr/steps/tar_test.py
@@ -271,7 +271,7 @@ def test_tar_archive_one_pass():
 
     mock_tarfile.assert_called_once_with('./blah.tar.xz', 'w:xz')
     (mock_tarfile.return_value.
-     __enter__().add.assert_called_once_with('path/to/dir'))
+     __enter__().add.assert_called_once_with('path/to/dir', arcname='.'))
 
 
 def test_tar_archive_one_pass_with_interpolation():
@@ -291,7 +291,7 @@ def test_tar_archive_one_pass_with_interpolation():
 
     mock_tarfile.assert_called_once_with('./blah.tar.value1', 'w:xz')
     (mock_tarfile.return_value.
-     __enter__().add.assert_called_once_with('value2/to/dir'))
+     __enter__().add.assert_called_once_with('value2/to/dir', arcname='.'))
 
 
 def test_tar_archive_one_pass_without_compression():
@@ -311,7 +311,7 @@ def test_tar_archive_one_pass_without_compression():
 
     mock_tarfile.assert_called_once_with('./blah.tar.xz', 'w:')
     (mock_tarfile.return_value.
-     __enter__().add.assert_called_once_with('path/to/dir'))
+     __enter__().add.assert_called_once_with('path/to/dir', arcname='.'))
 
 
 def test_tar_archive_one_pass_with_gz():
@@ -331,7 +331,7 @@ def test_tar_archive_one_pass_with_gz():
 
     mock_tarfile.assert_called_once_with('./blah.tar.gz', 'w:gz')
     (mock_tarfile.return_value.
-     __enter__().add.assert_called_once_with('path/to/dir'))
+     __enter__().add.assert_called_once_with('path/to/dir', arcname='.'))
 
 
 def test_tar_archive_pass():
@@ -357,8 +357,8 @@ def test_tar_archive_pass():
     (mock_tarfile.return_value.
      __enter__().add.call_count == 2)
     (mock_tarfile.return_value.
-     __enter__().add.assert_any_call('path/to/dir'))
+     __enter__().add.assert_any_call('path/to/dir', arcname='.'))
     (mock_tarfile.return_value.
-     __enter__().add.assert_any_call('.'))
+     __enter__().add.assert_any_call('.', arcname='.'))
 
 # ------------------------- tar archive --------------------------------------#


### PR DESCRIPTION
- tar archive would take an inpath like */path/to/mydir* and tar the entire path as */path/to/mydir*, rather than just add *mydir* to the tar. As of now, only the destination dir, and not its parents, will end up in the tar.
- version bump