### PR TITLE
assert step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1130,10 +1130,10 @@ values like this:
 
 .. code-block:: text
 
-  '{root}[0]' = list index 0
+  '{root[0]}' = list index 0
   '{root[1][key1]}' = this is a value from a dict containing a list, which contains a dict at index 1
   '{root[1][key2]}' = key 2 value
-  '{root}[2]' = list index 1
+  '{root[2]}' = list index 1
 
 
 sic strings

--- a/README.rst
+++ b/README.rst
@@ -432,7 +432,7 @@ Complex types:
 
 
 See a worked example `for assert here
-  <https://github.com/pypyr/pypyr-example/tree/master/pipelines/assert.yaml>`__.
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/assert.yaml>`__.
 
 pypyr.steps.contextclear
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -275,6 +275,9 @@ Built-in steps
 +-------------------------------+-------------------------------------------------+------------------------------+
 | **step**                      | **description**                                 | **input context properties** |
 +-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.assert`_         | Stop pipeline if item in context is not as      | assertThis (any)             |
+|                               | expected.                                       | assertEquals (any)           |
++-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.contextclear`_   | Remove specified items from context.            | contextClear (list)          |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.contextclearall`_| Wipe the entire context.                        |                              |
@@ -328,6 +331,105 @@ Built-in steps
 |                               | compression. Supports gzip, bzip2, lzma.        |                              |
 |                               |                                                 | tarArchive (dict)            |
 +-------------------------------+-------------------------------------------------+------------------------------+
+
+pypyr.steps.assert
+^^^^^^^^^^^^^^^^^^
+Assert that something is True or equal to something else.
+
+Uses these context keys:
+
+- ``assertThis``
+
+  - mandatory
+  - If assertEquals not specified, evaluates as a boolean.
+
+- ``assertEquals``
+
+  - optional
+  - If specified, compares ``assertThis`` to ``assertEquals``
+
+If ``assertThis`` evaluates to False raises error.
+
+If ``assertEquals`` is specified, raises error if ``assertThis != assertEquals``.
+
+Supports `Substitutions`_.
+
+Examples:
+
+.. code-block:: yaml
+
+    # continue pipeline
+    assertThis: True
+    # stop pipeline
+    assertThis: False
+
+or with substitutions:
+
+.. code-block:: yaml
+
+    interestingValue: True
+    assertThis: '{interestingValue}' # continue with pipeline
+
+Non-0 numbers evalute to True:
+
+.. code-block:: yaml
+
+    assertThis: 1 # non-0 numbers assert to True. continue with pipeline
+
+String equality:
+
+.. code-block:: yaml
+
+    assertThis: 'up the valleys wild'
+    assertEquals: 'down the valleys wild' # strings not equal. stop pipeline.
+
+String equality with substitutions:
+
+.. code-block:: yaml
+
+    k1: 'down'
+    k2: 'down'
+    assertThis: '{k1} the valleys wild'
+    assertEquals: '{k2} the valleys wild' # substituted strings equal. continue pipeline.
+
+
+Number equality:
+
+.. code-block:: yaml
+
+    assertThis: 123.45
+    assertEquals: 123.45 # numbers equal. continue with pipeline.
+
+Number equality with substitutions:
+
+.. code-block:: yaml
+
+    numberOne: 123.45
+    numberTwo: 678.9
+    assertThis: '{numberOne}'
+    assertEquals: '{numberTwo}' # substituted numbers not equal. Stop pipeline.
+
+Complex types:
+
+.. code-block:: yaml
+
+  complexOne:
+    - thing1
+    - k1: value1
+      k2: value2
+      k3:
+        - sub list 1
+        - sub list 2
+  complexTwo:
+    - thing1
+    - k1: value1
+      k2: value2
+      k3:
+        - sub list 1
+        - sub list 2
+  assertThis: '{complexOne}'
+  assertEquals: '{complexTwo}' # substituted types equal. Continue pipeline.
+
 
 pypyr.steps.contextclear
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -445,6 +547,8 @@ You can run:
 .. code-block:: bash
 
   $ pypyr look-ma-no-params
+
+Supports `Substitutions`_.
 
 pypyr.steps.env
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -92,8 +92,9 @@ Anatomy of a pypyr pipeline
 ***************************
 Pipeline yaml structure
 =======================
-A pipeline is a .yaml file. Save pipelines to a `pipelines` directory in your
-working directory.
+A pipeline is a .yaml file. pypyr uses YAML version 1.2.
+
+Save pipelines to a `pipelines` directory in your working directory.
 
 .. code-block:: yaml
 
@@ -1101,6 +1102,13 @@ Day-to-day testing
   .. code-block:: bash
 
     pytest tests/unit/arb_test_file.py
+
+**********
+Thank yous
+**********
+pypyr is fortunate to stand on the shoulders of a giant in the shape of the
+excellent `ruamel.yaml<https://pypi.python.org/pypi/ruamel.yaml>`_ library by
+Anthon van der Neut for all yaml parsing and validation.
 
 **********
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -1128,7 +1128,7 @@ other lists/dictionaries and so forth.
 Given the context above, you can use formatting expressions to access nested
 values like this:
 
-.. code-block:: python
+.. code-block:: text
 
   '{root}[0]' = list index 0
   '{root[1][key1]}' = this is a value from a dict containing a list, which contains a dict at index 1

--- a/README.rst
+++ b/README.rst
@@ -1110,8 +1110,31 @@ Escape literal curly braces with doubles: {{ for {, }} for }
 
 In json & yaml, curlies need to be inside quotes to make sure they parse as
 strings. Especially watch in .yaml, where { as the first character of a key or
-value will throw a formatting error if it's not in double quotes like this:
+value will throw a formatting error if it's not in quotes like this:
 *"{key}"*
+
+You can also reference keys nested deeper in the context hierarchy, in cases
+where you have a dictionary that contains lists/dictionaries that might contain
+other lists/dictionaries and so forth.
+
+.. code-block:: yaml
+
+  root:
+    - list index 0
+    - key1: this is a value from a dict containing a list, which contains a dict at index 1
+      key2: key 2 value
+    - list index 1
+
+Given the context above, you can use formatting expressions to access nested
+values like this:
+
+.. code-block:: python
+
+  '{root}[0]' = list index 0
+  '{root[1][key1]}' = this is a value from a dict containing a list, which contains a dict at index 1
+  '{root[1][key2]}' = key 2 value
+  '{root}[2]' = list index 1
+
 
 sic strings
 ===========

--- a/README.rst
+++ b/README.rst
@@ -1214,7 +1214,7 @@ Day-to-day testing
 Thank yous
 **********
 pypyr is fortunate to stand on the shoulders of a giant in the shape of the
-excellent `ruamel.yaml<https://pypi.python.org/pypi/ruamel.yaml>`_ library by
+excellent `ruamel.yaml <https://pypi.python.org/pypi/ruamel.yaml>`_ library by
 Anthon van der Neut for all yaml parsing and validation.
 
 **********

--- a/README.rst
+++ b/README.rst
@@ -430,6 +430,8 @@ Complex types:
   assertThis: '{complexOne}'
   assertEquals: '{complexTwo}' # substituted types equal. Continue pipeline.
 
+See a worked example `for assert here
+  <https://github.com/pypyr/pypyr-example/tree/master/pipelines/assert.yaml>`__.
 
 pypyr.steps.contextclear
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -430,6 +430,7 @@ Complex types:
   assertThis: '{complexOne}'
   assertEquals: '{complexTwo}' # substituted types equal. Continue pipeline.
 
+
 See a worked example `for assert here
   <https://github.com/pypyr/pypyr-example/tree/master/pipelines/assert.yaml>`__.
 

--- a/pypyr/steps/assert.py
+++ b/pypyr/steps/assert.py
@@ -1,0 +1,53 @@
+"""Step that asserts something is true or equal to something else."""
+import logging
+from pypyr.errors import ContextError
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Assert that something is True or equal to something else.
+
+    Args:
+        context: dictionary-like pypyr.context.Context. context is mandatory.
+        Uses the following context keys in context:
+            - assertThis. mandatory. Any type. If assertEquals not specified,
+              evals as boolean.
+            - assertEquals. optional. Any type.
+
+    If assertThis evaluates to False raises error.
+    If assertEquals is specified, raises error if assertThis != assertEquals.
+
+    assertThis & assertEquals both support string substitutions.
+
+    Returns:
+        None
+
+    Raises:
+        ContextError: if assert evalues to False.
+    """
+    logger.debug("started")
+    assert context, f"context must have value for {__name__}"
+    context.assert_key_has_value('assertThis', __name__)
+
+    assert_equals = context.get('assertEquals', None)
+
+    if assert_equals is None:
+        # nothing to compare to means treat assertThis as a bool.
+        logger.debug("Evaluating assertThis as a boolean.")
+        assert_result = context.get_formatted_as_type(context['assertThis'],
+                                                      out_type=bool)
+    else:
+        # compare assertThis to assertEquals
+        logger.debug("Comparing assertThis to assertEquals.")
+        assert_result = (context.get_formatted('assertThis')
+                         ==
+                         context.get_formatted('assertEquals'))
+
+    logger.info(f"assert evaluated to {assert_result}")
+
+    if not assert_result:
+        raise ContextError("assert evaluated to False.")
+
+    logger.debug("done")

--- a/pypyr/steps/assert.py
+++ b/pypyr/steps/assert.py
@@ -31,19 +31,17 @@ def run_step(context):
     assert context, f"context must have value for {__name__}"
     context.assert_key_has_value('assertThis', __name__)
 
-    assert_equals = context.get('assertEquals', None)
-
-    if assert_equals is None:
-        # nothing to compare to means treat assertThis as a bool.
-        logger.debug("Evaluating assertThis as a boolean.")
-        assert_result = context.get_formatted_as_type(context['assertThis'],
-                                                      out_type=bool)
-    else:
+    if 'assertEquals' in context:
         # compare assertThis to assertEquals
         logger.debug("Comparing assertThis to assertEquals.")
         assert_result = (context.get_formatted('assertThis')
                          ==
                          context.get_formatted('assertEquals'))
+    else:
+        # nothing to compare to means treat assertThis as a bool.
+        logger.debug("Evaluating assertThis as a boolean.")
+        assert_result = context.get_formatted_as_type(context['assertThis'],
+                                                      out_type=bool)
 
     logger.info(f"assert evaluated to {assert_result}")
 

--- a/pypyr/steps/assert.py
+++ b/pypyr/steps/assert.py
@@ -25,7 +25,7 @@ def run_step(context):
         None
 
     Raises:
-        ContextError: if assert evalues to False.
+        ContextError: if assert evaluates to False.
     """
     logger.debug("started")
     assert context, f"context must have value for {__name__}"

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.11'
+__version__ = '0.5.12'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.11
+current_version = 0.5.12
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/steps/assert_test.py
+++ b/tests/unit/pypyr/steps/assert_test.py
@@ -1,0 +1,392 @@
+"""assert.py unit tests."""
+import importlib
+from pypyr.context import Context
+from pypyr.errors import (ContextError,
+                          KeyNotInContextError,
+                          KeyInContextHasNoValueError)
+import pytest
+
+assert_step = None
+
+
+def setup_module(module):
+    """Setup any state specific to the execution of the given module."""
+    # loading assert dynamically because it clashes with built-in assert
+    global assert_step
+    assert_step = importlib.import_module('pypyr.steps.assert')
+
+
+def test_assert_raises_on_empty_context():
+    """context must exist."""
+    with pytest.raises(AssertionError):
+        assert_step.run_step(Context())
+
+
+def test_assert_raises_on_missing_assertthis():
+    """assertThis must exist."""
+    context = Context({'k1': 'v1'})
+    with pytest.raises(KeyNotInContextError):
+        assert_step.run_step(context)
+
+
+def test_assert_raises_on_empty_assertthis():
+    """assertThis must not be empty."""
+    context = Context({'assertThis': None})
+    with pytest.raises(KeyInContextHasNoValueError):
+        assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_false():
+    """assertThis boolean False raises."""
+    context = Context({'assertThis': False})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_true():
+    """assertThis boolean True passes."""
+    context = Context({'assertThis': True})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_int():
+    """assertThis int 1 is True."""
+    context = Context({'assertThis': 1})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_arb_int():
+    """assertThis non-0 int is True."""
+    context = Context({'assertThis': 55})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_arb_negative_int():
+    """assertThis non-0 int is True."""
+    context = Context({'assertThis': -55})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_float():
+    """assertThis non 0 float is True."""
+    context = Context({'assertThis': 3.5})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_false_string():
+    """assertThis arbitrary string isn't True raises."""
+    context = Context({'assertThis': 'arb string'})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_raises_on_assertthis_false_int():
+    """assertThis int 0 is False."""
+    context = Context({'assertThis': 0})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_true_string():
+    """assertThis boolean string to True passes."""
+    context = Context({'assertThis': 'True'})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals():
+    """assertThis does not equal assertEquals."""
+    context = Context({'assertThis': 'boom',
+                       'assertEquals': 'BOOM'})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_equals():
+    """assertThis equals assertEquals."""
+    context = Context({'assertThis': 'boom',
+                       'assertEquals': 'boom'})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_equals_bools():
+    """assertThis equals assertEquals true bools."""
+    context = Context({'assertThis': True,
+                       'assertEquals': True})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_equals_bools_false():
+    """assertThis equals assertEquals false bools."""
+    context = Context({'assertThis': False,
+                       'assertEquals': False})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_bools():
+    """assertThis does not equal assertEquals bools."""
+    context = Context({'assertThis': True,
+                       'assertEquals': False})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_equals_ints():
+    """assertThis equals assertEquals true ints."""
+    context = Context({'assertThis': 33,
+                       'assertEquals': 33})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_ints():
+    """assertThis does not equal assertEquals ints."""
+    context = Context({'assertThis': 0,
+                       'assertEquals': 23})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_equals_floats():
+    """assertThis equals assertEquals true ints."""
+    context = Context({'assertThis': 123.45,
+                       'assertEquals': 123.45})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_floats():
+    """assertThis does not equal assertEquals ints."""
+    context = Context({'assertThis': 123.45,
+                       'assertEquals': 5.432})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_raises_on_assertthis_not_equals_string_to_int():
+    """assertThis does not equal assertEquals string to int conversion."""
+    context = Context({'assertThis': '23',
+                       'assertEquals': 23})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_raises_on_assertthis_not_equals_string_to_bool():
+    """assertThis string does not equal assertEquals bool."""
+    context = Context({'assertThis': True,
+                       'assertEquals': 'True'})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_equals_lists():
+    """assertThis equals assertEquals true list."""
+    context = Context({'assertThis': [1, 2, 3, 4.5],
+                       'assertEquals': [1, 2, 3, 4.5]})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_lists():
+    """assertThis string does not equal assertEquals list."""
+    context = Context({'assertThis': [1, 2, 8, 4.5],
+                       'assertEquals': [1, 2, 3, 4.5]})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_equals_dicts():
+    """assertThis equals assertEquals true dict."""
+    context = Context({'assertThis': {'k1': 1, 'k2': [2, 3], 'k3': False},
+                       'assertEquals': {'k1': 1, 'k2': [2, 3], 'k3': False}})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_dict_to_list():
+    """assertThis string does not equal assertEquals dict."""
+    context = Context({'assertThis': {'k1': 1, 'k2': [2, 3], 'k3': False},
+                       'assertEquals': [1, 2, 3, 4.5]})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_raises_on_assertthis_not_equals_dict_to_dict():
+    """assertThis string does not equal assertEquals dict."""
+    context = Context({'assertThis': {'k1': 1, 'k2': [2, 3], 'k3': False},
+                       'assertEquals': {'k1': 1, 'k2': [2, 55], 'k3': False}})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+# ---------------------- substitutions ----------------------------------------
+
+
+def test_assert_passes_on_assertthis_equals_ints_substitutions():
+    """assertThis equals assertEquals true ints with substitutions."""
+    context = Context({'k1': 33,
+                       'k2': 33,
+                       'assertThis': '{k1}',
+                       'assertEquals': '{k2}'})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_ints_substitutions():
+    """assertThis string does not equal assertEquals bool."""
+    context = Context({'k1': 33,
+                       'k2': 34,
+                       'assertThis': '{k1}',
+                       'assertEquals': '{k2}'})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_not_equals_bools_substitutions():
+    """Format expressions equivocates string True and bool True."""
+    context = Context({'k1': True,
+                       'k2': 'True',
+                       'assertThis': '{k1}',
+                       'assertEquals': '{k2}'})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_not_equals_none_substitutions():
+    """None equals None."""
+    context = Context({'k1': None,
+                       'k2': None,
+                       'assertThis': '{k1}',
+                       'assertEquals': '{k2}'})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_true_substitutions():
+    """Format expressions equivocates string True and bool True."""
+    context = Context({'k1': True,
+                       'k2': 'True',
+                       'assertThis': '{k1}'})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_none_substitutions():
+    """assertThis string does not equal assertEquals with a None."""
+    context = Context({'k1': None,
+                       'k2': 34,
+                       'assertThis': '{k1}',
+                       'assertEquals': '{k2}'})
+    with pytest.raises(ContextError):
+        assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_bool_substitutions():
+    """assertThis string substituted bool evaluates False."""
+    context = Context({'k1': False,
+                       'k2': 34,
+                       'assertThis': '{k1}'})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_raises_on_assertthis_substitutions_int():
+    """Format expressions doesn't equivocates int 1 and bool True."""
+    context = Context({'k1': 1,
+                       'k2': 'True',
+                       'assertThis': '{k1}'})
+
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_raises_on_assertthis_none_substitutions():
+    """assertThis string substituted None evaluates False."""
+    context = Context({'k1': None,
+                       'k2': 34,
+                       'assertThis': '{k1}'})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")
+
+
+def test_assert_passes_on_assertthis_equals_dicts_substitutions():
+    """assertThis equals assertEquals true dict."""
+    context = Context({'k1': 'v1',
+                       'k2': 'v1',
+                       'assertThis': {'k1': 1,
+                                      'k2': [2, '{k1}'],
+                                      'k3': False},
+                       'assertEquals': {'k1': 1,
+                                        'k2': [2, '{k2}'],
+                                        'k3': False}})
+    assert_step.run_step(context)
+
+
+def test_assert_passes_on_assertthis_equals_dict_substitutions():
+    """assertThis equals assertEquals true dict."""
+    context = Context({'k1': 'v1',
+                       'k2': 'v1',
+                       'dict1': {'k1': 1,
+                                 'k2': [2, '{k1}'],
+                                 'k3': False},
+                       'dict2': {'k1': 1,
+                                 'k2': [2, '{k1}'],
+                                 'k3': False},
+                       'assertThis': '{dict1}',
+                       'assertEquals': '{dict2}'})
+    assert_step.run_step(context)
+
+
+def test_assert_raises_on_assertthis_not_equals_dict_to_dict_substitutions():
+    """assertThis string does not equal assertEquals dict."""
+    context = Context({'k1': 'v1',
+                       'k2': 'v2',
+                       'assertThis': {'k1': 1,
+                                      'k2': [2, '{k1}'],
+                                      'k3': False},
+                       'assertEquals': {'k1': 1,
+                                        'k2': [2, '{k2}'],
+                                        'k3': False}})
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError('assert evaluated to False.',)")


### PR DESCRIPTION
- add pypyr.steps.assert. Provide debug .assert style functionality in a pypyr step
- README updates 
  - assert
  - nested formatting expressions
  - thank yous
- bump version