### PR TITLE
contextsetf, and nicer assert errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,8 +283,12 @@ Built-in steps
 | `pypyr.steps.contextclearall`_| Wipe the entire context.                        |                              |
 |                               |                                                 |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.contextset`_     | Sets context values from already existing       | contextSet (dict)            |
+| `pypyr.steps.contextset`_     | Set context values from already existing        | contextSet (dict)            |
 |                               | context values.                                 |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.contextsetf`_    | Set context keys from formatting                | contextSetf (dict)           |
+|                               | expressions with {token} substitutions.         |                              |
+|                               |                                                 |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.echo`_           | Echo the context value `echoMe` to the output.  | echoMe (string)              |
 +-------------------------------+-------------------------------------------------+------------------------------+
@@ -534,6 +538,52 @@ This will result in context like this:
     key2: value1
     key3: value3
     key4: value3
+
+See a worked example `for contextset here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/contextset.yaml>`__.
+
+pypyr.steps.contextsetf
+^^^^^^^^^^^^^^^^^^^^^^^
+Set context keys from formatting expressions with `Substitutions`_.
+
+Requires the following context:
+
+.. code-block:: yaml
+
+  contextsetf:
+    newkey: '{format expression}'
+    newkey2: '{format expression}'
+
+For example, say your context looks like this:
+
+.. code-block:: yaml
+
+      key1: value1
+      key2: value2
+      answer: 42
+
+and your pipeline yaml looks like this:
+
+.. code-block:: yaml
+
+  steps:
+    - name: pypyr.steps.contextsetf
+      in:
+        contextSetf:
+          key2: any old value without a substitution - it will be a string now.
+          key4: 'What do you get when you multiply six by nine? {answer}'
+
+This will result in context like this:
+
+.. code-block:: yaml
+
+    key1: value1
+    key2: any old value without a substitution - it will be a string now.
+    answer: 42
+    key4: 'What do you get when you multiply six by nine? 42'
+
+See a worked example `for contextsetf here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/contextset.yaml>`__.
 
 pypyr.steps.echo
 ^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -409,6 +409,27 @@ Number equality with substitutions:
     assertThis: '{numberOne}'
     assertEquals: '{numberTwo}' # substituted numbers not equal. Stop pipeline.
 
+
+
+  GOTCHA: a string formatting expression like ``{numberOne}`` will always return
+  a string. This means a comparison to a number type will fail even if it looks
+  like the same number.
+
+.. code-block:: yaml
+
+  n1: 42
+  assertThis: '{n1}'
+  assertEquals: 42 # stop pipeline. '42' != 42 (str vs int)
+
+vs
+
+.. code-block:: yaml
+
+  n1: 42
+  assertThis: '{n1}'
+  assertEquals: '42' # continue pipeline. '42' == '42' (str vs str)
+
+
 Complex types:
 
 .. code-block:: yaml

--- a/README.rst
+++ b/README.rst
@@ -409,25 +409,24 @@ Number equality with substitutions:
     assertThis: '{numberOne}'
     assertEquals: '{numberTwo}' # substituted numbers not equal. Stop pipeline.
 
-
-
-  GOTCHA: a string formatting expression like ``{numberOne}`` will always return
+GOTCHA:
+  A string formatting expression like ``{numberOne}`` will always return
   a string. This means a comparison to a number type will fail even if it looks
   like the same number.
 
-.. code-block:: yaml
+  .. code-block:: yaml
 
-  n1: 42
-  assertThis: '{n1}'
-  assertEquals: 42 # stop pipeline. '42' != 42 (str vs int)
+    meaningOfLife: 42
+    assertThis: '{meaningOfLife}'
+    assertEquals: 42 # stop pipeline. '42' != 42 (str vs int)
 
-vs
+  vs
 
-.. code-block:: yaml
+  .. code-block:: yaml
 
-  n1: 42
-  assertThis: '{n1}'
-  assertEquals: '42' # continue pipeline. '42' == '42' (str vs str)
+    meaningOfLife: 42
+    assertThis: '{meaningOfLife}'
+    assertEquals: '42' # continue pipeline. '42' == '42' (str vs str)
 
 
 Complex types:

--- a/pypyr/steps/assert.py
+++ b/pypyr/steps/assert.py
@@ -33,12 +33,12 @@ def run_step(context):
 
     if 'assertEquals' in context:
         # compare assertThis to assertEquals
-        logger.debug("Comparing assertThis to assertEquals.")
+        logger.debug("comparing assertThis to assertEquals.")
         assert_result = (context.get_formatted('assertThis')
                          ==
                          context.get_formatted('assertEquals'))
     else:
-        # nothing to compare to means treat assertThis as a bool.
+        # nothing to compare means treat assertThis as a bool.
         logger.debug("Evaluating assertThis as a boolean.")
         assert_result = context.get_formatted_as_type(context['assertThis'],
                                                       out_type=bool)
@@ -46,6 +46,19 @@ def run_step(context):
     logger.info(f"assert evaluated to {assert_result}")
 
     if not assert_result:
-        raise ContextError("assert evaluated to False.")
+        assert_equals = context.get('assertEquals', None)
+
+        if assert_equals is None:
+            # if it's a bool it's presumably not a sensitive value.
+            error_text = (
+                f"assert {context['assertThis']} evaluated to False.")
+        else:
+            # emit type to help user, but not the actual field contents.
+            error_text = (
+                f"assert context['assertThis'] is of type "
+                f"{type(context.get_formatted('assertThis')).__name__} "
+                f"and does not equal context['assertEquals'] of type "
+                f"{type(context.get_formatted('assertEquals')).__name__}.")
+        raise ContextError(error_text)
 
     logger.debug("done")

--- a/pypyr/steps/contextsetf.py
+++ b/pypyr/steps/contextsetf.py
@@ -1,0 +1,44 @@
+"""pypyr step that sets context values from formatting expressions.
+
+This is handy if you need to prepare certain keys in context where a next step
+might need a specific key. If you already have the value in context, you can
+create a new key (or update existing key) with that value.
+"""
+import logging
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Set new context keys from formatting expressions with substitutions.
+
+    Context is a dictionary or dictionary-like.
+    context['contextSetf'] must exist. It's a dictionary.
+    Will iterate context['contextSetf'] and save the values as new keys to the
+    context.
+
+    For example, say input context is:
+        key1: value1
+        key2: value2
+        key3: value3
+        contextSetf:
+            key2: 'aaa_{key1}_zzz'
+            key4: 'bbb_{key3}_yyy'
+
+    This will result in return context:
+        key1: value1
+        key2: aaa_value1_zzz
+        key3: bbb_value3_yyy
+        key4: value3
+    """
+    logger.debug("started")
+    context.assert_key_has_value(key='contextSetf', caller=__name__)
+
+    for k, v in context['contextSetf'].items():
+        logger.debug(f"setting context {k} to value from context {v}")
+        context[k] = context.get_formatted_iterable(v)
+
+    logger.info(f"Set {len(context['contextSetf'])} context items.")
+
+    logger.debug("done")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.5.12'
+__version__ = '0.5.13'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.12
+current_version = 0.5.13
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/steps/assert_test.py
+++ b/tests/unit/pypyr/steps/assert_test.py
@@ -43,7 +43,7 @@ def test_assert_raises_on_assertthis_false():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError('assert False evaluated to False.',)")
 
 
 def test_assert_passes_on_assertthis_true():
@@ -83,7 +83,7 @@ def test_assert_raises_on_assertthis_false_string():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError('assert arb string evaluated to False.',)")
 
 
 def test_assert_raises_on_assertthis_false_int():
@@ -93,7 +93,7 @@ def test_assert_raises_on_assertthis_false_int():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError('assert 0 evaluated to False.',)")
 
 
 def test_assert_passes_on_assertthis_true_string():
@@ -110,7 +110,8 @@ def test_assert_raises_on_assertthis_not_equals():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type "
+        "str and does not equal context['assertEquals'] of type str.\",)")
 
 
 def test_assert_passes_on_assertthis_equals():
@@ -142,7 +143,8 @@ def test_assert_raises_on_assertthis_not_equals_bools():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type bool and does "
+        "not equal context['assertEquals'] of type bool.\",)")
 
 
 def test_assert_passes_on_assertthis_equals_ints():
@@ -160,7 +162,8 @@ def test_assert_raises_on_assertthis_not_equals_ints():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type int and does "
+        "not equal context['assertEquals'] of type int.\",)")
 
 
 def test_assert_passes_on_assertthis_equals_floats():
@@ -178,7 +181,8 @@ def test_assert_raises_on_assertthis_not_equals_floats():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type float and "
+        "does not equal context['assertEquals'] of type float.\",)")
 
 
 def test_assert_raises_on_assertthis_not_equals_string_to_int():
@@ -189,7 +193,8 @@ def test_assert_raises_on_assertthis_not_equals_string_to_int():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type str and does "
+        "not equal context['assertEquals'] of type int.\",)")
 
 
 def test_assert_raises_on_assertthis_not_equals_string_to_bool():
@@ -200,7 +205,8 @@ def test_assert_raises_on_assertthis_not_equals_string_to_bool():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type bool and does "
+        "not equal context['assertEquals'] of type str.\",)")
 
 
 def test_assert_passes_on_assertthis_equals_lists():
@@ -218,7 +224,8 @@ def test_assert_raises_on_assertthis_not_equals_lists():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type list and does "
+        "not equal context['assertEquals'] of type list.\",)")
 
 
 def test_assert_passes_on_assertthis_equals_dicts():
@@ -236,7 +243,8 @@ def test_assert_raises_on_assertthis_not_equals_dict_to_list():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type dict and does "
+        "not equal context['assertEquals'] of type list.\",)")
 
 
 def test_assert_raises_on_assertthis_not_equals_dict_to_dict():
@@ -247,7 +255,8 @@ def test_assert_raises_on_assertthis_not_equals_dict_to_dict():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type dict and does "
+        "not equal context['assertEquals'] of type dict.\",)")
 
 # ---------------------- substitutions ----------------------------------------
 
@@ -271,7 +280,8 @@ def test_assert_raises_on_assertthis_not_equals_ints_substitutions():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type str and does "
+        "not equal context['assertEquals'] of type str.\",)")
 
 
 def test_assert_passes_on_assertthis_not_equals_bools_substitutions():
@@ -319,7 +329,7 @@ def test_assert_raises_on_assertthis_bool_substitutions():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError('assert {k1} evaluated to False.',)")
 
 
 def test_assert_raises_on_assertthis_substitutions_int():
@@ -332,7 +342,7 @@ def test_assert_raises_on_assertthis_substitutions_int():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError('assert {k1} evaluated to False.',)")
 
 
 def test_assert_raises_on_assertthis_none_substitutions():
@@ -344,7 +354,7 @@ def test_assert_raises_on_assertthis_none_substitutions():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError('assert {k1} evaluated to False.',)")
 
 
 def test_assert_passes_on_assertthis_equals_dicts_substitutions():
@@ -389,4 +399,5 @@ def test_assert_raises_on_assertthis_not_equals_dict_to_dict_substitutions():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError('assert evaluated to False.',)")
+        "ContextError(\"assert context['assertThis'] is of type dict and does "
+        "not equal context['assertEquals'] of type dict.\",)")

--- a/tests/unit/pypyr/steps/contextsetf_test.py
+++ b/tests/unit/pypyr/steps/contextsetf_test.py
@@ -1,0 +1,257 @@
+"""contextsetf.py unit tests."""
+from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
+import pypyr.steps.contextsetf
+import pytest
+
+
+def test_contextsetf_throws_on_empty_context():
+    """context must exist."""
+    with pytest.raises(KeyNotInContextError):
+        pypyr.steps.contextsetf.run_step(Context())
+
+
+def test_contextsetf_throws_on_contextset_missing():
+    """contextSetf must exist in context."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.contextsetf.run_step(Context({'arbkey': 'arbvalue'}))
+
+    assert repr(err_info.value) == (
+        "KeyNotInContextError(\"context['contextSetf'] "
+        "doesn't exist. It must exist for "
+        "pypyr.steps.contextsetf.\",)")
+
+
+def test_contextsetf_pass_no_substitutions():
+    """contextsetf success case with no substitutions."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'contextSetf': {
+            'key2': 'value4',
+            'key4': 'value5'
+        }
+    })
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'value4'
+    assert context['key3'] == 'value3'
+    assert context['key4'] == 'value5'
+
+
+def test_contextsetf_pass_substitutions():
+    """contextsetf success case with substitutions."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'contextSetf': {
+            'key2': '{key1}',
+            'key4': '{key3}'
+        }
+    })
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'value1'
+    assert context['key3'] == 'value3'
+    assert context['key4'] == 'value3'
+
+
+def test_contextsetf_pass_different_types():
+    """contextset success case with substitutions of non strings."""
+    context = Context({
+        'k1': 33,
+        'k2': 123.45,
+        'k3': False,
+        'contextSetf': {
+            'kint': '{k1}',
+            'kfloat': '{k2}',
+            'kbool': '{k3}'
+        }
+    })
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    assert context['kint'] == '33'
+    assert context['k1'] == 33
+    assert context['kfloat'] == '123.45'
+    assert context['k2'] == 123.45
+    assert context['kbool'] == 'False'
+    assert not context['k3']
+
+
+def test_contextsetf_list():
+    """Simple list"""
+    context = Context({'ctx1': 'ctxvalue1',
+                       'ctx2': 'ctxvalue2',
+                       'ctx3': 'ctxvalue3',
+                       'contextSetf': {
+                           'output': ['k1', 'k2', '{ctx3}', True, False, 44]
+                       }})
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    output = context['output']
+    assert output[0] == 'k1'
+    assert output[1] == 'k2'
+    assert output[2] == 'ctxvalue3'
+    assert output[3]
+    assert not output[4]
+    assert output[5] == 44
+
+
+def test_contextsetf_tuple():
+    """Simple tuple"""
+    context = Context({'ctx1': 'ctxvalue1',
+                       'ctx2': 'ctxvalue2',
+                       'ctx3': 'ctxvalue3',
+                       'contextSetf': {
+                           'output': ('k1', 'k2', '{ctx3}', True, False, 44)
+                       }})
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    output = context['output']
+    assert output[0] == 'k1'
+    assert output[1] == 'k2'
+    assert output[2] == 'ctxvalue3'
+    assert output[3]
+    assert not output[4]
+    assert output[5] == 44
+
+
+def test_contextsetf_set():
+    """Simple set"""
+    input_obj = {'k1', 'k2', '{ctx3}', True, False, 44}
+    context = Context({'ctx1': 'ctxvalue1',
+                       'ctx2': 'ctxvalue2',
+                       'ctx3': 'ctxvalue3',
+                       'contextSetf': {
+                           'output': input_obj
+                       }})
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    output = context['output']
+    assert len(output) == len(input_obj)
+    diffs = output - input_obj
+    assert len(diffs) == 1
+    assert 'ctxvalue3' in diffs
+
+
+def test_contextsetf_nested():
+    """Straight deepish copy with no formatting."""
+    # dict containing dict, list, dict-list-dict, tuple, dict-tuple-list
+    input_obj = {'k1': 'v1',
+                 'k2': 'v2',
+                 'k3': 'v3',
+                 'k4': [
+                     1,
+                     2,
+                     '3here',
+                     {'key4.1': 'value4.1',
+                      'key4.2': 'value4.2',
+                      'key4.3': {
+                          '4.3.1': '4.3.1value',
+                          '4.3.2': '4.3.2value'}}
+                 ],
+                 'k5': {'key5.1': 'value5.1', 'key5.2': 'value5.2'},
+                 'k6': ('six6.1', False, [0, 1, 2], 77, 'sixend'),
+                 'k7': 'simple string to close 7'
+                 }
+
+    context = Context({'ctx1': 'ctxvalue1',
+                       'ctx2': 'ctxvalue2',
+                       'ctx3': 'ctxvalue3',
+                       'contextSetf': {
+                           'output': input_obj}})
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    output = context['output']
+    assert output == input_obj
+    assert output is not context
+    # verify this was a deep copy - obj refs has to be different for nested
+    assert id(output['k4']) != id(input_obj['k4'])
+    assert id(output['k4'][3]['key4.3']) != id(input_obj['k4'][3]['key4.3'])
+    assert id(output['k5']) != id(input_obj['k5'])
+    assert id(output['k6']) != id(input_obj['k6'])
+    assert id(output['k6'][2]) != id(input_obj['k6'][2])
+    assert id(output['k7']) == id(input_obj['k7'])
+
+    # and proving the theory: mutating output does not touch input
+    assert output['k4'][1] == 2
+    output['k4'][1] = 88
+    assert input_obj['k4'][1] == 2
+    assert output['k4'][1] == 88
+
+
+def test_get_formatted_iterable_nested_with_formatting():
+    """Straight deepish copy with formatting."""
+    # dict containing dict, list, dict-list-dict, tuple, dict-tuple-list, bytes
+    input_obj = {'k1': 'v1',
+                 'k2': 'v2_{ctx1}',
+                 'k3': bytes('v3{ctx1}', encoding='utf-8'),
+                 'k4': [
+                     1,
+                     2,
+                     '3_{ctx4}here',
+                     {'key4.1': 'value4.1',
+                      '{ctx2}_key4.2': 'value_{ctx3}_4.2',
+                      'key4.3': {
+                          '4.3.1': '4.3.1value',
+                          '4.3.2': '4.3.2_{ctx1}_value'}}
+                 ],
+                 'k5': {'key5.1': 'value5.1', 'key5.2': 'value5.2'},
+                 'k6': ('six6.1', False, [0, 1, 2], 77, 'six_{ctx1}_end'),
+                 'k7': 'simple string to close 7'
+                 }
+
+    context = Context(
+        {'ctx1': 'ctxvalue1',
+         'ctx2': 'ctxvalue2',
+         'ctx3': 'ctxvalue3',
+         'ctx4': 'ctxvalue4',
+         'contextSetf': {
+             'output': input_obj}})
+
+    pypyr.steps.contextsetf.run_step(context)
+
+    output = context['output']
+    assert output != input_obj
+
+    # verify formatted strings
+    assert input_obj['k2'] == 'v2_{ctx1}'
+    assert output['k2'] == 'v2_ctxvalue1'
+
+    assert input_obj['k3'] == b'v3{ctx1}'
+    assert output['k3'] == b'v3{ctx1}'
+
+    assert input_obj['k4'][2] == '3_{ctx4}here'
+    assert output['k4'][2] == '3_ctxvalue4here'
+
+    assert input_obj['k4'][3]['{ctx2}_key4.2'] == 'value_{ctx3}_4.2'
+    assert output['k4'][3]['ctxvalue2_key4.2'] == 'value_ctxvalue3_4.2'
+
+    assert input_obj['k4'][3]['key4.3']['4.3.2'] == '4.3.2_{ctx1}_value'
+    assert output['k4'][3]['key4.3']['4.3.2'] == '4.3.2_ctxvalue1_value'
+
+    assert input_obj['k6'][4] == 'six_{ctx1}_end'
+    assert output['k6'][4] == 'six_ctxvalue1_end'
+
+    # verify this was a deep copy - obj refs has to be different for nested
+    assert id(output['k4']) != id(input_obj['k4'])
+    assert id(output['k4'][3]['key4.3']) != id(input_obj['k4'][3]['key4.3'])
+    assert id(output['k5']) != id(input_obj['k5'])
+    assert id(output['k6']) != id(input_obj['k6'])
+    assert id(output['k6'][2]) != id(input_obj['k6'][2])
+    # strings are interned in python, so id is the same
+    assert id(output['k7']) == id(input_obj['k7'])
+    output['k7'] = 'mutate 7 on new'
+    assert input_obj['k7'] == 'simple string to close 7'
+    assert output['k7'] == 'mutate 7 on new'


### PR DESCRIPTION
- contextsetf step. Set context keys from formatting expressions with {substitutions}.
- assert step - friendlier error messages include type information
- README updates for new functionality
- bump