### PR TITLE
twine deployment url change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1036,6 +1036,9 @@ adults here, pypyr does not protect you from infinite recursion other than the
 default python recursion limit. So don't come crying if you blew your stack. Or
 a seal.
 
+Here is a worked example of `pype recursion
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/pype-recursion.yaml>`_.
+
 pypyr.steps.pypyrversion
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Outputs the same as:

--- a/ops/shippable-pypi-release.sh
+++ b/ops/shippable-pypi-release.sh
@@ -20,7 +20,7 @@ pip uninstall -y pypyr
 python setup.py bdist_wheel
 
 # Deploy wheel
-twine upload --repository-url ${PYPI_URL} --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD} dist/pypyr-${NEW_VERSION}-py3-none-any.whl
+twine upload --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD} dist/pypyr-${NEW_VERSION}-py3-none-any.whl
 
 echo "----------Done with twine upload-------------------------------------"
 

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 
 [bdist_wheel]
 universal = 0


### PR DESCRIPTION
- let twine choose pypi url rather than specify it
- minor README updates for pype recursion