### PR TITLE
ruamel.yaml upgrade to >0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so

--- a/README.rst
+++ b/README.rst
@@ -880,6 +880,10 @@ The following context keys expected:
 
 The file in and out paths support `Substitutions`_.
 
+See a worked example of
+`fileformatyaml
+<https://github.com/pypyr/pypyr-example/blob/master/pipelines/fileformatyaml.yaml>`_.
+
 pypyr.steps.filereplace
 ^^^^^^^^^^^^^^^^^^^^^^^
 Parses input text file and replaces a search string.

--- a/pypyr/parser/yamlfile.py
+++ b/pypyr/parser/yamlfile.py
@@ -16,7 +16,8 @@ def get_parsed_context(context_arg):
     logger.debug("starting")
     logger.debug(f"attempting to open file: {context_arg}")
     with open(context_arg) as yaml_file:
-        payload = yaml.safe_load(yaml_file)
+        yaml_loader = yaml.YAML(typ='safe', pure=True)
+        payload = yaml_loader.load(yaml_file)
 
     logger.debug(f"yaml file parsed. Count: {len(payload)}")
 

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -92,7 +92,8 @@ def get_pipeline_definition(pipeline_name, working_dir):
     logger.debug(f"Trying to open pipeline at path {pipeline_path}")
     try:
         with open(pipeline_path) as yaml_file:
-            pipeline_definition = yaml.safe_load(yaml_file)
+            yaml_loader = yaml.YAML(typ='safe', pure=True)
+            pipeline_definition = yaml_loader.load(yaml_file)
             logger.debug(
                 f"found {len(pipeline_definition)} stages in pipeline.")
     except FileNotFoundError:

--- a/pypyr/steps/assert.py
+++ b/pypyr/steps/assert.py
@@ -34,8 +34,7 @@ def run_step(context):
     if 'assertEquals' in context:
         # compare assertThis to assertEquals
         logger.debug("comparing assertThis to assertEquals.")
-        assert_result = (context.get_formatted('assertThis')
-                         ==
+        assert_result = (context.get_formatted('assertThis') ==
                          context.get_formatted('assertEquals'))
     else:
         # nothing to compare means treat assertThis as a bool.

--- a/pypyr/steps/fetchyaml.py
+++ b/pypyr/steps/fetchyaml.py
@@ -36,7 +36,8 @@ def run_step(context):
 
     logger.debug(f"attempting to open file: {file_path}")
     with open(file_path) as yaml_file:
-        payload = yaml.safe_load(yaml_file)
+        yaml_loader = yaml.YAML(typ='safe', pure=True)
+        payload = yaml_loader.load(yaml_file)
 
     if not isinstance(payload, MutableMapping):
         raise TypeError("yaml input should describe a dictionary at the top "

--- a/pypyr/steps/fileformatyaml.py
+++ b/pypyr/steps/fileformatyaml.py
@@ -38,19 +38,17 @@ def run_step(context):
     in_path = context.get_formatted('fileFormatYamlIn')
     out_path = context.get_formatted('fileFormatYamlOut')
 
+    yaml_loader = yaml.YAML(typ='rt', pure=True)
+
     logger.debug(f"opening yaml source file: {in_path}")
     with open(in_path) as infile:
-        payload = yaml.load(infile, Loader=yaml.RoundTripLoader)
+        payload = yaml_loader.load(infile)
 
     logger.debug(f"opening destination file for writing: {out_path}")
     os.makedirs(os.path.abspath(os.path.dirname(out_path)), exist_ok=True)
     with open(out_path, 'w') as outfile:
         formatted_iterable = context.get_formatted_iterable(payload)
-        yaml.dump(formatted_iterable,
-                  outfile,
-                  Dumper=yaml.RoundTripDumper,
-                  allow_unicode=True,
-                  width=50)
+        yaml_loader.dump(formatted_iterable, outfile)
 
     logger.info(
         f"Read {in_path} yaml, formatted contents and wrote to {out_path}")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.6.1'
+__version__ = '0.7.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.7.0
 
 [bdist_wheel]
 universal = 0

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['ruamel.yaml<0.15'],
+    install_requires=['ruamel.yaml'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -85,7 +85,7 @@ def test_get_parser_context_signature_wrong(mocked_moduleloader):
 # ------------------------- get_pipeline_definition --------------------------#
 
 
-@patch('ruamel.yaml.safe_load', return_value='mocked pipeline def')
+@patch('ruamel.yaml.YAML.load', return_value='mocked pipeline def')
 @patch('pypyr.moduleloader.get_pipeline_path', return_value='arb/path/x.yaml')
 def test_get_pipeline_definition_pass(mocked_get_path,
                                       mocked_yaml):

--- a/tests/unit/pypyr/steps/fileformatyaml_test.py
+++ b/tests/unit/pypyr/steps/fileformatyaml_test.py
@@ -82,7 +82,8 @@ def test_fileformatyaml_pass_no_substitutions():
     assert context['fileFormatYamlOut'] == './tests/testfiles/out/out.yaml'
 
     with open('./tests/testfiles/out/out.yaml') as outfile:
-        outcontents = yaml.load(outfile, Loader=yaml.RoundTripLoader)
+        yaml_loader = yaml.YAML(typ='rt', pure=True)
+        outcontents = yaml_loader.load(outfile)
 
     assert len(outcontents) == 3
     assert outcontents['key'] == 'value1 !£$%# *'
@@ -124,7 +125,8 @@ def test_fileformatyaml_pass_with_substitutions():
                                             'outsubst.yaml')
 
     with open('./tests/testfiles/out/outsubst.yaml') as outfile:
-        outcontents = yaml.load(outfile, Loader=yaml.RoundTripLoader)
+        yaml_loader = yaml.YAML(typ='rt', pure=True)
+        outcontents = yaml_loader.load(outfile)
 
     expected = {
         'key': 'v1value1 !£$%# *',
@@ -174,7 +176,8 @@ def test_fileformatyaml_pass_with_path_substitutions():
                                             '{pathOut}.yaml')
 
     with open('./tests/testfiles/out/outsubst.yaml') as outfile:
-        outcontents = yaml.load(outfile, Loader=yaml.RoundTripLoader)
+        yaml_loader = yaml.YAML(typ='rt', pure=True)
+        outcontents = yaml_loader.load(outfile)
 
     expected = {
         'key': 'v1value1 !£$%# *',


### PR DESCRIPTION
- upgrade version for new pypi release
- update ruamel.yaml to >0.15. This is a major, interface breaking change on the part of ruamel. pypyr consumers are not affected, however.
- add fileformatyaml.yaml example
- .pytest_cache to gitignore
- minor formatting change on new linting rules for = on a single line