### PR TITLE
Step Decorators: run, skip, swallow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,7 @@ Save pipelines to a `pipelines` directory in your working directory.
         parameter2: value2
       run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
       skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
+      swallow: False # optional. Swallows any errors raised by the step. Defaults to False if not specified.
 
   # optional.
   on_success:
@@ -288,7 +289,7 @@ Don't bother specifying these unless you want to deviate from the default values
         parameter2: value2
       run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
       skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
-
+      swallow: False # optional. Swallows any errors raised by the step. Defaults to False if not specified.
 
 +---------------+----------+---------------------------------------------+----------------+
 | **decorator** | **type** | **description**                             | **default**    |
@@ -309,6 +310,11 @@ Don't bother specifying these unless you want to deviate from the default values
 |               |          | combine *run* and *skip* in the same        |                |
 |               |          | pipeline to toggle at runtime which steps   |                |
 |               |          | you want to execute.                        |                |
++---------------+--------------------------------------------------------+----------------+
+| swallow       | bool     | If True, ignore any errors raised by the    | False          |
+|               |          | step and continue to the next step.         |                |
+|               |          | pypyr logs the error, so you'll know what   |                |
+|               |          | happened, but processing continues.         |                |
 +---------------+--------------------------------------------------------+----------------+
 
 All step decorators support `Substitutions`_.

--- a/README.rst
+++ b/README.rst
@@ -327,7 +327,7 @@ Simply put, this means that 1, TRUE, True and true will be True.
 None/Empty, 0,'', [], {} will be False.
 
 See a worked example for `step decorators here
-<https://github.com/pypyr/pypyr-example/tree/master/pipelines/stepdecorators.yaml>`__.
+<https://github.com/pypyr/pypyr-example/blob/master/pipelines/stepdecorators.yaml>`__.
 
 Built-in steps
 --------------

--- a/README.rst
+++ b/README.rst
@@ -111,9 +111,10 @@ Save pipelines to a `pipelines` directory in your working directory.
     - mymodule # simple step pointing at a python file
     - name: my.package.another.module # complex step. It contains a description and in parameters.
       description: Optional description is for humans. It's any text that makes your life easier.
-      in: #optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
+      in: # optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
         parameter1: value1
         parameter2: value2
+      run: True # optional. Runs this step if True, skips steps if false. Defaults to True if not specified.
 
   # optional.
   on_success:
@@ -268,6 +269,47 @@ You can specify a step in the pipeline yaml in two ways:
 
 * Frankly, the only reason simple steps are there is because I'm lazy and I dislike redundant typing.
 
+Step decorators
+---------------
+
+Complex steps have various optional step decorators that change how or if a step is run.
+
+Don't bother specifying these unless you want to deviate from the default values.
+
+
+.. code-block:: yaml
+
+  steps:
+    - name: my.package.another.module
+      description: Optional Description is for humans. It's any yaml-escaped text that makes your life easier.
+      in: # optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
+        parameter1: value1
+        parameter2: value2
+      run: True # optional. Runs this step if True, skips steps if false. Defaults to True if not specified.
+
+
++---------------+----------+---------------------------------------------+----------------+
+| **decorator** | **type** | **description**                             | **default**    |
++---------------+--------------------------------------------------------+----------------+
+| in            | dict     | Add this to the context so that this        | None           |
+|               |          | step and subsequent steps can use these     |                |
+|               |          | key-value pairs.                            |                |
++---------------+--------------------------------------------------------+----------------+
+| run           | bool     | Runs this step if True, skips steps if      | True           |
+|               |          | false.                                      |                |
++---------------+--------------------------------------------------------+----------------+
+
+All step decorators support `Substitutions`_.
+
+Note that for all bool values, the standard Python truth value testing rules apply.
+https://docs.python.org/3/library/stdtypes.html#truth-value-testing
+
+Simply put, this means that 1, TRUE, True and true will be True.
+
+None/Empty, 0,'', [], {} will be False.
+
+See a worked example for `step decorators here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/stepdecorators.yaml>`__.
 
 Built-in steps
 --------------

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,8 @@ Save pipelines to a `pipelines` directory in your working directory.
       in: # optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
         parameter1: value1
         parameter2: value2
-      run: True # optional. Runs this step if True, skips steps if false. Defaults to True if not specified.
+      run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
+      skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
 
   # optional.
   on_success:
@@ -285,7 +286,8 @@ Don't bother specifying these unless you want to deviate from the default values
       in: # optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
         parameter1: value1
         parameter2: value2
-      run: True # optional. Runs this step if True, skips steps if false. Defaults to True if not specified.
+      run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
+      skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
 
 
 +---------------+----------+---------------------------------------------+----------------+
@@ -295,8 +297,18 @@ Don't bother specifying these unless you want to deviate from the default values
 |               |          | step and subsequent steps can use these     |                |
 |               |          | key-value pairs.                            |                |
 +---------------+--------------------------------------------------------+----------------+
-| run           | bool     | Runs this step if True, skips steps if      | True           |
-|               |          | false.                                      |                |
+| run           | bool     | Runs this step if True, skips step if       | True           |
+|               |          | False.                                      |                |
++---------------+--------------------------------------------------------+----------------+
+| skip          | bool     | Skips this step if True, runs step if       | False          |
+|               |          | False. Evaluates after the *run* decorator. |                |
+|               |          |                                             |                |
+|               |          | If this looks like it's merely the inverse  |                |
+|               |          | of *run*, that's because it is. Use         |                |
+|               |          | whichever suits your pipeline better, or    |                |
+|               |          | combine *run* and *skip* in the same        |                |
+|               |          | pipeline to toggle at runtime which steps   |                |
+|               |          | you want to execute.                        |                |
 +---------------+--------------------------------------------------------+----------------+
 
 All step decorators support `Substitutions`_.

--- a/README.rst
+++ b/README.rst
@@ -293,14 +293,14 @@ Don't bother specifying these unless you want to deviate from the default values
 
 +---------------+----------+---------------------------------------------+----------------+
 | **decorator** | **type** | **description**                             | **default**    |
-+---------------+--------------------------------------------------------+----------------+
++---------------+----------+---------------------------------------------+----------------+
 | in            | dict     | Add this to the context so that this        | None           |
 |               |          | step and subsequent steps can use these     |                |
 |               |          | key-value pairs.                            |                |
-+---------------+--------------------------------------------------------+----------------+
++---------------+----------+---------------------------------------------+----------------+
 | run           | bool     | Runs this step if True, skips step if       | True           |
 |               |          | False.                                      |                |
-+---------------+--------------------------------------------------------+----------------+
++---------------+----------+---------------------------------------------+----------------+
 | skip          | bool     | Skips this step if True, runs step if       | False          |
 |               |          | False. Evaluates after the *run* decorator. |                |
 |               |          |                                             |                |
@@ -310,7 +310,7 @@ Don't bother specifying these unless you want to deviate from the default values
 |               |          | combine *run* and *skip* in the same        |                |
 |               |          | pipeline to toggle at runtime which steps   |                |
 |               |          | you want to execute.                        |                |
-+---------------+--------------------------------------------------------+----------------+
++---------------+----------+---------------------------------------------+----------------+
 | swallow       | bool     | If True, ignore any errors raised by the    | False          |
 |               |          | step and continue to the next step.         |                |
 |               |          | pypyr logs the error, so you'll know what   |                |

--- a/README.rst
+++ b/README.rst
@@ -315,7 +315,7 @@ Don't bother specifying these unless you want to deviate from the default values
 |               |          | step and continue to the next step.         |                |
 |               |          | pypyr logs the error, so you'll know what   |                |
 |               |          | happened, but processing continues.         |                |
-+---------------+--------------------------------------------------------+----------------+
++---------------+----------+---------------------------------------------+----------------+
 
 All step decorators support `Substitutions`_.
 

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -345,11 +345,11 @@ class Context(dict):
                 # casting a str to bool is always True, hence special case. If
                 # the str value is 'False'/'false', presumably user can
                 # reasonably expect a bool False response.
-                return result == 'True'
+                return result.lower() in ['true', '1', '1.0']
             else:
                 return out_type(result)
         else:
-            return value
+            return out_type(value)
 
     def get_processed_string(self, input_string):
         """Runs token substitution on input_string against context.
@@ -389,7 +389,7 @@ class Context(dict):
             KeyError: input_string is not a sic string and has {somekey} where
                       somekey does not exist in context dictionary.
         """
-        if input_string[:6] == '[sic]"':
+        if input_string[: 6] == '[sic]"':
             return input_string[6: -1]
         else:
             return input_string.format(**self)

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -119,18 +119,27 @@ def run_pipeline_steps(steps, context):
         step_count = 0
 
         for step in steps:
+            run_me = True
+
             if isinstance(step, dict):
                 logger.debug(f"{step} is complex.")
                 step_name = step['name']
 
                 if 'in' in step:
                     get_step_input_context(step['in'], context)
+
+                # run: optional value, true by default. Allow substitution.
+                run_me = context.get_formatted_as_type(
+                    step.get('run', True), out_type=bool)
             else:
                 logger.debug(f"{step} is a simple string.")
                 step_name = step
 
-            run_pipeline_step(step_name=step_name,
-                              context=context)
+            if run_me:
+                run_pipeline_step(step_name=step_name, context=context)
+            else:
+                logger.info(f"{step_name} not running because run is False.")
+
             step_count += 1
 
         logger.debug(f"executed {step_count} steps")

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -120,6 +120,7 @@ def run_pipeline_steps(steps, context):
 
         for step in steps:
             run_me = True
+            skip_me = False
 
             if isinstance(step, dict):
                 logger.debug(f"{step} is complex.")
@@ -131,12 +132,20 @@ def run_pipeline_steps(steps, context):
                 # run: optional value, true by default. Allow substitution.
                 run_me = context.get_formatted_as_type(
                     step.get('run', True), out_type=bool)
+
+                # skip: optional value, false by default. Allow substitution.
+                skip_me = context.get_formatted_as_type(
+                    step.get('skip', False), out_type=bool)
             else:
                 logger.debug(f"{step} is a simple string.")
                 step_name = step
 
             if run_me:
-                run_pipeline_step(step_name=step_name, context=context)
+                if not skip_me:
+                    run_pipeline_step(step_name=step_name, context=context)
+                else:
+                    logger.info(
+                        f"{step_name} not running because skip is True.")
             else:
                 logger.info(f"{step_name} not running because run is False.")
 

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -121,10 +121,11 @@ def run_pipeline_steps(steps, context):
         for step in steps:
             run_me = True
             skip_me = False
+            swallow_me = False
 
             if isinstance(step, dict):
-                logger.debug(f"{step} is complex.")
                 step_name = step['name']
+                logger.debug(f"{step_name} is complex.")
 
                 if 'in' in step:
                     get_step_input_context(step['in'], context)
@@ -136,13 +137,26 @@ def run_pipeline_steps(steps, context):
                 # skip: optional value, false by default. Allow substitution.
                 skip_me = context.get_formatted_as_type(
                     step.get('skip', False), out_type=bool)
+
+                # swallow: optional, defaults false. Allow substitution.
+                swallow_me = context.get_formatted_as_type(
+                    step.get('swallow', False), out_type=bool)
             else:
                 logger.debug(f"{step} is a simple string.")
                 step_name = step
 
             if run_me:
                 if not skip_me:
-                    run_pipeline_step(step_name=step_name, context=context)
+                    try:
+                        run_pipeline_step(step_name=step_name, context=context)
+                    except Exception as ex_info:
+                        if swallow_me:
+                            logger.error(
+                                f"{step_name} Ignoring error because swallow "
+                                "is True for this step.\n"
+                                f"{type(ex_info).__name__}: {ex_info}")
+                        else:
+                            raise
                 else:
                     logger.info(
                         f"{step_name} not running because skip is True.")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.8.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -885,6 +885,87 @@ def test_get_formatted_as_type_bool_true_with_subst():
     assert result
 
 
+def test_get_formatted_as_type_bool_true_with_list_input():
+    """get_formatted_as_type returns bool True with arbitrary input"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type([0, 1, 2], out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
+def test_get_formatted_as_type_bool_false_with_empty_list_input():
+    """get_formatted_as_type returns bool false with empty input"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type([], out_type=bool)
+
+    assert isinstance(result, bool)
+    assert not result
+
+
+def test_get_formatted_as_type_bool_false_with_0_input():
+    """get_formatted_as_type returns bool False with 0 input"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type(0, out_type=bool)
+
+    assert isinstance(result, bool)
+    assert not result
+
+
+def test_get_formatted_as_type_bool_false_with_string_capital_false():
+    """get_formatted_as_type returns bool False with string FALSE"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type('FALSE', out_type=bool)
+
+    assert isinstance(result, bool)
+    assert not result
+
+
+def test_get_formatted_as_type_bool_true_with_1_input():
+    """get_formatted_as_type returns bool True with int 1 input"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type(1, out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
+def test_get_formatted_as_type_bool_true_with_decimal_input():
+    """get_formatted_as_type returns bool True with decimal input"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type(1.1, out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
+def test_get_formatted_as_type_bool_true_with_str_true():
+    """get_formatted_as_type returns bool True with string true"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type('true', out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
+def test_get_formatted_as_type_bool_true_with_str_capital_true():
+    """get_formatted_as_type returns bool True with string TRUE"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type('TRUE', out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
+def test_get_formatted_as_type_bool_true_with_str_1_true():
+    """get_formatted_as_type returns bool True with string 1"""
+    context = Context({'k1': True})
+    result = context.get_formatted_as_type('1', out_type=bool)
+
+    assert isinstance(result, bool)
+    assert result
+
+
 def test_get_formatted_as_type_int_no_subst():
     """get_formatted_as_type returns int no formatting"""
     context = Context()

--- a/tests/unit/pypyr/steps/assert_test.py
+++ b/tests/unit/pypyr/steps/assert_test.py
@@ -333,8 +333,8 @@ def test_assert_raises_on_assertthis_bool_substitutions():
 
 
 def test_assert_raises_on_assertthis_substitutions_int():
-    """Format expressions doesn't equivocates int 1 and bool True."""
-    context = Context({'k1': 1,
+    """Format expressions doesn't equivocates int 0 and bool True."""
+    context = Context({'k1': 0,
                        'k2': 'True',
                        'assertThis': '{k1}'})
 
@@ -343,6 +343,15 @@ def test_assert_raises_on_assertthis_substitutions_int():
 
     assert repr(err_info.value) == (
         "ContextError('assert {k1} evaluated to False.',)")
+
+
+def test_assert_assertthis_int_1_is_true():
+    """Format expressions equivocates int 1 and bool True."""
+    context = Context({'k1': 1,
+                       'k2': 'True',
+                       'assertThis': '{k1}'})
+
+    assert_step.run_step(context)
 
 
 def test_assert_raises_on_assertthis_none_substitutions():

--- a/tests/unit/pypyr/stepsrunner_test.py
+++ b/tests/unit/pypyr/stepsrunner_test.py
@@ -338,6 +338,8 @@ def test_run_pipeline_steps_complex_with_in(mock_run_step):
     # validate all the in params ended up in context as intended
     assert len(context) - 2 == original_len
 
+# -----------------------  run_pipeline_steps: run -----------------------#
+
 
 @patch('pypyr.stepsrunner.run_pipeline_step')
 def test_run_pipeline_steps_complex_with_run_true(mock_run_step):
@@ -610,7 +612,7 @@ def test_run_pipeline_steps_complex_with_run_99_true(
     """Complex step with run 99 runs step."""
     steps = [{
         'name': 'step1',
-        # 1 will evaluate True because it's an int and > 0
+        # 99 will evaluate True because it's an int and > 0
         'run': 99
     }]
 
@@ -646,7 +648,7 @@ def test_run_pipeline_steps_complex_with_run_neg1_true(
     """Complex step with run -1 runs step."""
     steps = [{
         'name': 'step1',
-        # 1 will evaluate True because it's an int and > 0
+        # -1 will evaluate True because it's an int and != 0
         'run': -1
     }]
 
@@ -781,6 +783,442 @@ def test_run_pipeline_steps_complex_with_multistep_none_run(
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
 
+# -----------------------  END run_pipeline_steps: run -----------------------#
+
+# -----------------------  run_pipeline_steps: skip --------------------------#
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_false(mock_run_step):
+    """Complex step with skip decorator set false will run step."""
+    steps = [{
+        'name': 'step1',
+        'skip': False
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_debug.assert_any_call("executed 1 steps")
+    mock_run_step.assert_called_once_with(
+        step_name='step1', context={'key1': 'value1',
+                                    'key2': 'value2',
+                                    'key3': 'value3',
+                                    'key4': [
+                                        {'k4lk1': 'value4',
+                                         'k4lk2': 'value5'},
+                                        {'k4lk1': 'value6',
+                                         'k4lk2': 'value7'}
+                                    ],
+                                    'key5': False,
+                                    'key6': True,
+                                    'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_true(mock_run_step):
+    """Complex step with skip decorator set true runa step."""
+    steps = [{
+        'name': 'step1',
+        'skip': True
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_str_formatting_false(
+        mock_run_step):
+    """Complex step with skip formatting expression false doesn't run step."""
+    steps = [{
+        'name': 'step1',
+        # name will evaluate True
+        'skip': '{key6}'
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_str_true(
+        mock_run_step):
+    """Complex step with skip set to string False doesn't run step."""
+    steps = [{
+        'name': 'step1',
+        # skip evaluates True because it's a string and TRUE parses to True.
+        'skip': 'TRUE'
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_str_lower_true(
+        mock_run_step):
+    """Complex step with run set to string true doesn't run step."""
+    steps = [{
+        'name': 'step1',
+        # skip will evaluate true because it's a string and true is True.
+        'skip': 'true'
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_run_and_skip_bool_formatting_false(
+        mock_run_step):
+    """Complex step with run doesn't run step, evals before skip."""
+    steps = [{
+        'name': 'step1',
+        # key5 will evaluate False because it's a bool and it's False
+        'run': '{key5}',
+        'skip': True
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because run is False.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_bool_formatting_false(
+        mock_run_step):
+    """Complex step with skip formatting expression true runs step."""
+    steps = [{
+        'name': 'step1',
+        # key5 will evaluate False because it's a bool and it's False
+        'skip': '{key5}'
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_debug.assert_any_call("executed 1 steps")
+    mock_run_step.assert_called_once_with(
+        step_name='step1', context={'key1': 'value1',
+                                    'key2': 'value2',
+                                    'key3': 'value3',
+                                    'key4': [
+                                        {'k4lk1': 'value4',
+                                         'k4lk2': 'value5'},
+                                        {'k4lk1': 'value6',
+                                         'k4lk2': 'value7'}
+                                    ],
+                                    'key5': False,
+                                    'key6': True,
+                                    'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_string_false(
+        mock_run_step):
+    """Complex step with skip formatting expression False runs step."""
+    steps = [{
+        'name': 'step1',
+        # 'False' will evaluate bool False
+        'skip': 'False'
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_debug.assert_any_call("executed 1 steps")
+    mock_run_step.assert_called_once_with(
+        step_name='step1', context={'key1': 'value1',
+                                    'key2': 'value2',
+                                    'key3': 'value3',
+                                    'key4': [
+                                        {'k4lk1': 'value4',
+                                         'k4lk2': 'value5'},
+                                        {'k4lk1': 'value6',
+                                         'k4lk2': 'value7'}
+                                    ],
+                                    'key5': False,
+                                    'key6': True,
+                                    'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_0_true(
+        mock_run_step):
+    """Complex step with run 1 runs step."""
+    steps = [{
+        'name': 'step1',
+        # 0 will evaluate False because it's an int and 0
+        'skip': 0
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_debug.assert_any_call("executed 1 steps")
+    mock_run_step.assert_called_once_with(
+        step_name='step1', context={'key1': 'value1',
+                                    'key2': 'value2',
+                                    'key3': 'value3',
+                                    'key4': [
+                                        {'k4lk1': 'value4',
+                                         'k4lk2': 'value5'},
+                                        {'k4lk1': 'value6',
+                                         'k4lk2': 'value7'}
+                                    ],
+                                    'key5': False,
+                                    'key6': True,
+                                    'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_99_true(
+        mock_run_step):
+    """Complex step with skip 99 doesn't run step."""
+    steps = [{
+        'name': 'step1',
+        # 99 will evaluate True because it's an int and > 0
+        'skip': 99
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_skip_neg1_true(
+        mock_run_step):
+    """Complex step with run -1 runs step."""
+    steps = [{
+        'name': 'step1',
+        # -1 will evaluate True because it's an int and != 0
+        'skip': -1
+    }]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_mix_skip_and_not_skip(
+        mock_run_step):
+    """Complex steps, some run some don't."""
+    # Step 1 & 3 runs, 2 should not.
+    steps = [{
+        'name': 'step1',
+        'skip': False
+    },
+        {
+        'name': 'step2',
+        'skip': True
+    },
+        {
+        'name': 'step3',
+    },
+    ]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        with patch.object(logger, 'info') as mock_logger_info:
+            pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_debug.assert_any_call("executed 3 steps")
+    mock_logger_info.assert_any_call(
+        "step2 not running because skip is True.")
+
+    assert mock_run_step.call_count == 2
+    assert mock_run_step.mock_calls == [call(context={
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3', 'key4':
+        [
+            {
+                'k4lk1': 'value4',
+                'k4lk2': 'value5'},
+            {
+                'k4lk1': 'value6',
+                'k4lk2': 'value7'
+            }],
+        'key5': False,
+        'key6': True,
+        'key7': 77},
+        step_name='step1'),
+        call(context={
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': 'value3', 'key4':
+            [
+                {
+                    'k4lk1': 'value4',
+                    'k4lk2': 'value5'},
+                {
+                    'k4lk1': 'value6',
+                    'k4lk2': 'value7'
+                }],
+            'key5': False,
+            'key6': True,
+            'key7': 77},
+            step_name='step3')]
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.stepsrunner.run_pipeline_step')
+def test_run_pipeline_steps_complex_with_multistep_all_skip(
+        mock_run_step):
+    """Multiple steps and none run."""
+    # None of these should run - various shades of python true
+    steps = [{
+        'name': 'step1',
+        'skip': [1, 2, 3]
+    },
+        {
+        'name': 'step2',
+        'skip': 1
+    },
+        {
+        'name': 'step3',
+        'skip': True,
+    },
+        {
+        'name': 'step4',
+        # run evals before skip
+        'run': False,
+        'skip': False
+    },
+    ]
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.stepsrunner.run_pipeline_steps(steps, context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_logger_info.assert_any_call(
+        "step2 not running because skip is True.")
+    mock_logger_info.assert_any_call(
+        "step3 not running because skip is True.")
+    mock_logger_info.assert_any_call(
+        "step4 not running because run is False.")
+    mock_run_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+# -----------------------  END run_pipeline_steps: skip ----------------------#
+
 
 @patch('pypyr.stepsrunner.run_pipeline_step')
 def test_run_pipeline_steps_simple(mock_run_step):
@@ -792,6 +1230,8 @@ def test_run_pipeline_steps_simple(mock_run_step):
     mock_logger_debug.assert_any_call('step1 is a simple string.')
     mock_run_step.assert_called_once_with(
         step_name='step1', context={'k1': 'v1'})
+
+
 # ------------------------- run_pipeline_steps--------------------------------#
 
 # ------------------------- run_step_group------------------------------------#


### PR DESCRIPTION
- Add step decorators for run, skip and swallow
- You can now specify on the fly whether a step should run, be skipped or if any errors should be ignored.
- string to bool type conversions now cater for TRUE/true/True/1/1.0 casting to bool True
- fix bug on casting where return value is not actually cast to specified return_type
- Minor version release