### PR TITLE
remove --context arg, make positional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ pypyr executable. https://hub.docker.com/r/pypyr/pypyr/
 
 .. code-block:: bash
 
-  $ docker run pypyr/pypyr echo --context "echoMe=Ceci n'est pas une pipe"
+  $ docker run pypyr/pypyr echo "echoMe=Ceci n'est pas une pipe"
 
 
 *****
@@ -56,10 +56,10 @@ Run one of the built-in pipelines to get a feel for it:
 
 .. code-block:: bash
 
-  $ pypyr echo --context "echoMe=Ceci n'est pas une pipe"
+  $ pypyr echo "echoMe=Ceci n'est pas une pipe"
 
 You can achieve the same thing by running a pipeline where the context is set
-in the pipeline yaml rather than as a --context argument:
+in the pipeline yaml rather than passed in as the 2nd positional argument:
 
 .. code-block:: bash
 
@@ -82,10 +82,16 @@ pypyr assumes a pipelines directory in your current working directory.
   # If you don't specify --log it defaults to 20 - INFO logging level.
   $ pypyr mypipelinename
 
-  # run pipelines/mypipelinename.yaml with an input context. For this input to
-  # be available to your pipeline you need to specify a context_parser in your
+  # run pipelines/mypipelinename.yaml. The 2nd argument is any arbitrary string,
+  # known as the input context argument. For this input argument to be available
+  # to your pipeline you need to specify a context parser in your pipeline yaml.
+  $ pypyr mypipelinename arbitrary_string_here
+
+  # run pipelines/mypipelinename.yaml with an input context in key-value
+  # pair format. For this input to be available to your pipeline you need to
+  # specify a context_parser like pypyr.parser.keyvaluepairs in your
   # pipeline yaml.
-  $ pypyr mypipelinename --context 'mykey=value'
+  $ pypyr mypipelinename "mykey=value"
 
 Get cli help
 ============
@@ -146,18 +152,18 @@ Built-in pipelines
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | **pipeline**                | **description**                                 | **how to run**                                                                      |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| donothing                   | Does what it says. Nothing.                     |`pypyr donothing`                                                                    |
+| donothing                   | Does what it says. Nothing.                     |``pypyr donothing``                                                                  |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| echo                        | Echos context value echoMe to output.           |`pypyr echo --context "echoMe=text goes here"`                                       |
+| echo                        | Echos context value echoMe to output.           |``pypyr echo "echoMe=text goes here"``                                               |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyrversion                | Prints the python cli version number.           |`pypyr pypyrversion`                                                                 |
+| pypyrversion                | Prints the python cli version number.           |``pypyr pypyrversion``                                                               |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| magritte                    | Thoughts about pipes.                           |`pypyr magritte`                                                                     |
+| magritte                    | Thoughts about pipes.                           |``pypyr magritte``                                                                   |
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
@@ -166,9 +172,11 @@ context_parser
 ==============
 Optional.
 
-A context_parser parses the pypyr --context input argument. The chances are
-pretty good that it will take the --context argument and put in into the pypyr
-context.
+A context_parser parses the pypyr command's context input argument. This is the
+second positional argument from the command line.
+
+The chances are pretty good that the context_parser will take the context
+command argument and put in into the pypyr context.
 
 The pypyr context is a dictionary that is in scope for the duration of the entire
 pipeline. The context_parser can initialize the context. Any step in the pipeline
@@ -179,7 +187,7 @@ Built-in context parsers
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | **context parser**          | **description**                                 | **example input**                                                                   |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.commas         | Takes a comma delimited string and returns a    |``pypyr pipelinename --context "param1,param2,param3"``                              |
+| pypyr.parser.commas         | Takes a comma delimited string and returns a    |``pypyr pipelinename "param1,param2,param3"``                                        |
 |                             | dictionary where each element becomes the key,  |                                                                                     |
 |                             | with value to true.                             |This will create a context dictionary like this:                                     |
 |                             |                                                 |{'param1': True, 'param2': True, 'param3': True}                                     |
@@ -187,11 +195,11 @@ Built-in context parsers
 |                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
 |                             | a context key name of \' k2\' not \'k2\'.       |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.json           | Takes a json string and returns a dictionary.   |``pypyr pipelinename --context '{"key1":"value1","key2":"value2"}'``                 |
+| pypyr.parser.json           | Takes a json string and returns a dictionary.   |``pypyr pipelinename '{"key1":"value1","key2":"value2"}'``                           |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.jsonfile       | Opens json file and returns a dictionary.       |``pypyr pipelinename --context './path/sample.json'``                                |
+| pypyr.parser.jsonfile       | Opens json file and returns a dictionary.       |``pypyr pipelinename "./path/sample.json"``                                          |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.keyvaluepairs  | Takes a comma delimited key=value pair string   |``pypyr pipelinename --context "param1=value1,param2=value2,param3=value3"``         |
+| pypyr.parser.keyvaluepairs  | Takes a comma delimited key=value pair string   |``pypyr pipelinename "param1=value1,param2=value2,param3=value3"``                   |
 |                             | and returns a dictionary where each pair becomes|                                                                                     |
 |                             | a dictionary element.                           |                                                                                     |
 |                             |                                                 |                                                                                     |
@@ -199,14 +207,14 @@ Built-in context parsers
 |                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
 |                             | a context key name of \' k2\' not \'k2\'.       |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.list           | Takes a comma delimited string and returns a    |``pypyr pipelinename --context "param1,param2,param3"``                              |
+| pypyr.parser.list           | Takes a comma delimited string and returns a    |``pypyr pipelinename "param1,param2,param3"``                                        |
 |                             | list in context with name *argList*.            |                                                                                     |
 |                             |                                                 |This will create a context dictionary like this:                                     |
 |                             | Don't have spaces between commas unless you     |{'argList': ['param1', 'param2', 'param3']}                                          |
 |                             | really mean it. \"v1, v2\" will result in       |                                                                                     |
 |                             | argList[1] being \' v2\' not \'v2\'.            |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| pypyr.parser.yamlfile       | Opens a yaml file and writes the contents into  |``pypyr pipelinename --context './path/sample.yaml'``                                |
+| pypyr.parser.yamlfile       | Opens a yaml file and writes the contents into  |``pypyr pipelinename "./path/sample.yaml"``                                          |
 |                             | the pypyr context dictionary.                   |                                                                                     |
 |                             |                                                 |                                                                                     |
 |                             | The top (or root) level yaml should describe a  |                                                                                     |
@@ -241,11 +249,20 @@ Roll your own context_parser
 
 
   def get_parsed_context(context_arg):
-      """This is the signature for a context parser. Input context is the string received from pypyr --context 'value here'"""
-      assert context_arg, ("pipeline must be invoked with --context set.")
+      """This is the signature for a context parser.
+
+      Args:
+        context_arg: string. Passed from command-line invocation where
+                     pypyr pipelinename 'this is the context_arg'
+
+      Returns:
+        dict. This dict will initialize the context for the pipeline run.
+      """
+      assert context_arg, ("pipeline must be invoked with context set.")
       logger.debug("starting")
 
-      # your clever code here. Chances are pretty good you'll be doing things with the input context string to create a dictionary.
+      # your clever code here. Chances are pretty good you'll be doing things
+      # with the input context_arg string to create a dictionary.
 
       # function signature returns a dictionary
       return {'key1': 'value1', 'key2':'value2'}
@@ -744,7 +761,7 @@ You can run:
 
 .. code-block:: bash
 
-  pypyr mypipeline --context "echoMe=Ceci n'est pas une pipe"
+  pypyr mypipeline "echoMe=Ceci n'est pas une pipe"
 
 
 Alternatively, if you had pipelines/look-ma-no-params.yaml like this:
@@ -1141,7 +1158,7 @@ Example input context:
 |                       | must exist in the *working directory/pipelines* dir. |
 +-----------------------+------------------------------------------------------+
 | pipeArg               | String to pass to the child pipeline context_parser. |
-|                       | Equivalent to *--context* arg on the pypyr cli. Only |
+|                       | Equivalent to *context* arg on the pypyr cli. Only   |
 |                       | used if skipParse==False                             |
 +-----------------------+------------------------------------------------------+
 | raiseError            | If True, errors in child raised up to parent.        |

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ pypyr executable. https://hub.docker.com/r/pypyr/pypyr/
 
 .. code-block:: bash
 
-  $ docker run pypyr/pypyr echo "echoMe=Ceci n'est pas une pipe"
+  $ docker run pypyr/pypyr echo "Ceci n'est pas une pipe"
 
 
 *****
@@ -56,7 +56,7 @@ Run one of the built-in pipelines to get a feel for it:
 
 .. code-block:: bash
 
-  $ pypyr echo "echoMe=Ceci n'est pas une pipe"
+  $ pypyr echo "Ceci n'est pas une pipe"
 
 You can achieve the same thing by running a pipeline where the context is set
 in the pipeline yaml rather than passed in as the 2nd positional argument:
@@ -157,7 +157,7 @@ Built-in pipelines
 |                             |                                                 |                                                                                     |
 |                             |                                                 |                                                                                     |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
-| echo                        | Echos context value echoMe to output.           |``pypyr echo "echoMe=text goes here"``                                               |
+| echo                        | Echos context value echoMe to output.           |``pypyr echo "text goes here"``                                                      |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | pypyrversion                | Prints the python cli version number.           |``pypyr pypyrversion``                                                               |
 |                             |                                                 |                                                                                     |
@@ -213,6 +213,11 @@ Built-in context parsers
 |                             | Don't have spaces between commas unless you     |{'argList': ['param1', 'param2', 'param3']}                                          |
 |                             | really mean it. \"v1, v2\" will result in       |                                                                                     |
 |                             | argList[1] being \' v2\' not \'v2\'.            |                                                                                     |
++-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
+| pypyr.parser.string         | Takes any arbitrary string and returns a        |``pypyr pipelinename "arbitrary string here"``                                       |
+|                             | string in context with name *argString*.        |                                                                                     |
+|                             |                                                 |This will create a context dictionary like this:                                     |
+|                             |                                                 |{'argString': 'arbitrary string here'}                                               |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | pypyr.parser.yamlfile       | Opens a yaml file and writes the contents into  |``pypyr pipelinename "./path/sample.yaml"``                                          |
 |                             | the pypyr context dictionary.                   |                                                                                     |

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -28,9 +28,6 @@ def get_parser():
                         nargs='?',
                         help='String for context values. Parsed by the '
                         'pipeline\'s context_parser function.')
-    parser.add_argument('--context', dest='pipeline_context',
-                        help='Deprecated. Same thing as the pipeline_context '
-                             'positional arg.')
     parser.add_argument('--dir', dest='working_dir', default=os.getcwd(),
                         help='Working directory. Use if your pipelines '
                         'directory is elsewhere. Defaults to cwd.')

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -24,9 +24,13 @@ def get_parser():
     parser.add_argument('pipeline_name',
                         help='Name of pipeline to run. It should exist in the '
                         './pipelines directory.')
-    parser.add_argument('--context', dest='pipeline_context',
+    parser.add_argument(dest='pipeline_context',
+                        nargs='?',
                         help='String for context values. Parsed by the '
                         'pipeline\'s context_parser function.')
+    parser.add_argument('--context', dest='pipeline_context',
+                        help='Deprecated. Same thing as the pipeline_context '
+                             'positional arg.')
     parser.add_argument('--dir', dest='working_dir', default=os.getcwd(),
                         help='Working directory. Use if your pipelines '
                         'directory is elsewhere. Defaults to cwd.')

--- a/pypyr/parser/commas.py
+++ b/pypyr/parser/commas.py
@@ -14,9 +14,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with --context set. For "
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
                          "this commas parser you're looking for something "
-                         "like--context 'spam,eggs' or --context 'spam'."
+                         "like: pypyr pipelinename 'spam,eggs' \n"
+                         "or: pypyr pipelinename 'spam'."
                          )
     logger.debug("starting")
     # for each comma-delimited element, project (element-name, true)

--- a/pypyr/parser/json.py
+++ b/pypyr/parser/json.py
@@ -9,10 +9,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with --context set. For "
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
                          "this json parser you're looking for something "
-                         "like "
-                         "--context '{\"key1\":\"value1\","
+                         "like: "
+                         "pypyr pipelinename '{\"key1\":\"value1\","
                          "\"key2\":\"value2\"}'")
     logger.debug("starting")
     # deserialize the input context string into json

--- a/pypyr/parser/jsonfile.py
+++ b/pypyr/parser/jsonfile.py
@@ -9,9 +9,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with --context set. For "
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
                          "this json parser you're looking for something "
-                         "like --context './myjsonfile.json'")
+                         "like: "
+                         "pypyr pipelinename './myjsonfile.json'")
     logger.debug("starting")
     # open the json file on disk so that you can initialize the dictionary
     logger.debug(f"attempting to open file: {context_arg}")

--- a/pypyr/parser/keyvaluepairs.py
+++ b/pypyr/parser/keyvaluepairs.py
@@ -17,10 +17,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with --context set. For "
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
                          "this keyvaluepairs parser you're looking for "
-                         "something like "
-                         "--context 'key1=value1,key2=value2'.")
+                         "something like: "
+                         "pypyr pipelinename 'key1=value1,key2=value2'.")
     logger.debug("starting")
     # for each comma-delimited element, project key=value
     return dict(element.split('=') for element in context_arg.split(','))

--- a/pypyr/parser/list.py
+++ b/pypyr/parser/list.py
@@ -13,9 +13,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with --context set. For "
-                         "this list parser you're looking for something like"
-                         "--context 'spam,eggs' or --context 'spam'."
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
+                         "this list parser you're looking for something like: "
+                         "pypyr pipelinename 'spam,eggs' "
+                         "OR: pypyr pipelinename 'spam'."
                          )
     logger.debug("starting")
     # the list that's parsed from the input args is named argList

--- a/pypyr/parser/string.py
+++ b/pypyr/parser/string.py
@@ -1,0 +1,23 @@
+"""Context parser that adds the input argument string into the pypyr context.
+
+Takes any arbitrary string and adds it to the context dict as argString.
+
+So a string like this "ham eggs bacon", will yield context:
+{'argString': 'ham eggs bacon'}
+"""
+import logging
+
+# getLogger will grab the parent logger context, so your loglevel and
+# formatting will inherit correctly automatically from the pypyr core.
+logger = logging.getLogger(__name__)
+
+
+def get_parsed_context(context_arg):
+    """Parse input context string and returns context as dictionary."""
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
+                         "this string parser you're looking for something "
+                         "like: pypyr pipelinename 'spam and eggs'."
+                         )
+    logger.debug("starting")
+    # the list that's parsed from the input args is named argList
+    return dict({'argString': context_arg})

--- a/pypyr/parser/yamlfile.py
+++ b/pypyr/parser/yamlfile.py
@@ -10,9 +10,10 @@ logger = pypyr.log.logger.get_logger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with --context set. For "
+    assert context_arg, ("pipeline must be invoked with context arg set. For "
                          "this yaml parser you're looking for something "
-                         "like --context './myyamlfile.yaml'")
+                         "like: "
+                         "pypyr pipelinename './myyamlfile.yaml'")
     logger.debug("starting")
     logger.debug(f"attempting to open file: {context_arg}")
     with open(context_arg) as yaml_file:

--- a/pypyr/pipelines/echo.yaml
+++ b/pypyr/pipelines/echo.yaml
@@ -1,5 +1,10 @@
 # To execute this pipeline, shell something like:
-# pypyr echo --context "echoMe=text goes here"
-context_parser: pypyr.parser.keyvaluepairs
+# pypyr echo "text goes here"
+context_parser: pypyr.parser.string
 steps:
+  - name: pypyr.steps.contextset
+    description: assign input arg to echoMe so echo step can echo it.
+    in:
+      contextSet:
+        echoMe: argString
   - pypyr.steps.echo

--- a/pypyr/steps/echo.py
+++ b/pypyr/steps/echo.py
@@ -15,12 +15,12 @@ def run_step(context):
                  This logger could well be stdout.
 
     When you execute the pipeline, it should look something like this:
-    pypyr [name here] --context 'echoMe=test'.
+    pypyr [name here] 'echoMe=test', assuming a keyvaluepair context parser.
     """
     logger.debug("started")
 
     assert context, ("context must be set for echo. Did you set "
-                     "--context 'echoMe=text here'?")
+                     "'echoMe=text here'?")
 
     context.assert_key_exists('echoMe', __name__)
 

--- a/pypyr/steps/py.py
+++ b/pypyr/steps/py.py
@@ -17,7 +17,7 @@ def run_step(context):
 
     context is mandatory. When you execute the pipeline, it should look
     something like this:
-        pipeline-runner [name here] --context 'pycode=print(1+1)'.
+        pipeline-runner [name here] 'pycode=print(1+1)'.
     """
     logger.debug("started")
     context.assert_key_has_value(key='pycode', caller=__name__)

--- a/pypyr/steps/pype.py
+++ b/pypyr/steps/pype.py
@@ -21,7 +21,7 @@ def run_step(context):
                   {name}.yaml must exist in the working directory/pipelines
                   dir.
                 - pipeArg. string. optional. String to pass to the
-                  context_parser - the equivalent to --context arg on the
+                  context_parser - the equivalent to context arg on the
                   pypyr cli. Only used if skipParse==False.
                 - raiseError. bool. optional. Defaults to True. If False, log,
                   but swallow any errors that happen during the invoked

--- a/pypyr/steps/safeshell.py
+++ b/pypyr/steps/safeshell.py
@@ -20,7 +20,7 @@ def run_step(context):
     {{ or }}.
 
     context is mandatory. When you execute the pipeline, it should look
-    something like this: pipeline-runner [name here] --context 'cmd=ls -a'.
+    something like this: pipeline-runner [name here] 'cmd=ls -a'.
 
     context['cmd'] will interpolate anything in curly braces for values
     found in context. So if your context looks like this:

--- a/pypyr/steps/shell.py
+++ b/pypyr/steps/shell.py
@@ -24,7 +24,7 @@ def run_step(context):
     curly brace, double it like {{ or }}.
 
     context is mandatory. When you execute the pipeline, it should look
-    something like this: pipeline-runner [name here] --context 'cmd=ls -a'.
+    something like this: pipeline-runner [name here] 'cmd=ls -a'.
 
     context['cmd'] will interpolate anything in curly braces for values
     found in context. So if your context looks like this:

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.8.2'
+__version__ = '0.9.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.2
+current_version = 0.9.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -5,29 +5,6 @@ import pytest
 from unittest.mock import patch
 
 
-def test_main_pass_with_sysargv_context_flag():
-    """Invoke from cli sets sys.argv, check assigns correctly to args."""
-    arg_list = ['pypyr',
-                'blah',
-                '--log',
-                '50',
-                '--context',
-                'ctx string',
-                '--dir',
-                'dir here']
-
-    with patch('sys.argv', arg_list):
-        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
-            pypyr.cli.main()
-
-        mock_pipeline_main.assert_called_once_with(
-            pipeline_name='blah',
-            pipeline_context_input='ctx string',
-            working_dir='dir here',
-            log_level=50
-        )
-
-
 def test_main_pass_with_sysargv_context_positional():
     """Invoke from cli sets sys.argv, check assigns correctly to args."""
     arg_list = ['pypyr',
@@ -72,23 +49,6 @@ def test_main_pass_with_sysargv_context_positional_flags_last():
         )
 
 
-def test_main_pass_with_defaults_context_flag():
-    """Default values assigned - log 20 and cwd"""
-    arg_list = ['blah',
-                '--context',
-                'ctx string']
-
-    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
-        pypyr.cli.main(arg_list)
-
-    mock_pipeline_main.assert_called_once_with(
-        pipeline_name='blah',
-        pipeline_context_input='ctx string',
-        working_dir=os.getcwd(),
-        log_level=20
-    )
-
-
 def test_main_pass_with_defaults_context_positional():
     """Default values assigned - log 20 and cwd"""
     arg_list = ['blah',
@@ -102,28 +62,6 @@ def test_main_pass_with_defaults_context_positional():
         pipeline_context_input='ctx string',
         working_dir=os.getcwd(),
         log_level=20
-    )
-
-
-def test_main_pass_with_context_flag_overrides_positional():
-    """Default values assigned - log 22 and dir set"""
-    arg_list = ['blah',
-                'ctx string',
-                '--log',
-                '22',
-                '--dir',
-                'arb',
-                '--context',
-                'from flag']
-
-    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
-        pypyr.cli.main(arg_list)
-
-    mock_pipeline_main.assert_called_once_with(
-        pipeline_name='blah',
-        pipeline_context_input='from flag',
-        working_dir='arb',
-        log_level=22
     )
 
 
@@ -161,8 +99,8 @@ def test_main_pass_with_no_context_other_flags_set():
 
 def test_pipeline_name_required():
     """Error expected if no pipeline name"""
-    arg_list = ['--context',
-                'ctx string']
+    arg_list = ['--dir',
+                'blah']
 
     with patch('pypyr.pipelinerunner.main'):
         with pytest.raises(SystemExit) as exit_err:
@@ -175,7 +113,6 @@ def test_pipeline_name_required():
 def test_interrupt_signal():
     """Interrupt signal handled."""
     arg_list = ['blah',
-                '--context',
                 'ctx string']
 
     with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
@@ -187,7 +124,6 @@ def test_interrupt_signal():
 def test_arb_error():
     """Arbitrary error should return 255."""
     arg_list = ['blah',
-                '--context',
                 'ctx string']
 
     with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
@@ -199,7 +135,6 @@ def test_arb_error():
 def test_trace_log_level():
     """Log Level < 10 produces traceback on error."""
     arg_list = ['blah',
-                '--context',
                 'ctx string',
                 '--log',
                 '5']

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import patch
 
 
-def test_main_pass_with_sysargv():
+def test_main_pass_with_sysargv_context_flag():
     """Invoke from cli sets sys.argv, check assigns correctly to args."""
     arg_list = ['pypyr',
                 'blah',
@@ -28,7 +28,51 @@ def test_main_pass_with_sysargv():
         )
 
 
-def test_main_pass_with_defaults():
+def test_main_pass_with_sysargv_context_positional():
+    """Invoke from cli sets sys.argv, check assigns correctly to args."""
+    arg_list = ['pypyr',
+                'blah',
+                'ctx string',
+                '--log',
+                '50',
+                '--dir',
+                'dir here']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            pypyr.cli.main()
+
+        mock_pipeline_main.assert_called_once_with(
+            pipeline_name='blah',
+            pipeline_context_input='ctx string',
+            working_dir='dir here',
+            log_level=50
+        )
+
+
+def test_main_pass_with_sysargv_context_positional_flags_last():
+    """Check assigns correctly to args when positional last not first."""
+    arg_list = ['pypyr',
+                '--log',
+                '50',
+                '--dir',
+                'dir here',
+                'blah',
+                'ctx string', ]
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            pypyr.cli.main()
+
+        mock_pipeline_main.assert_called_once_with(
+            pipeline_name='blah',
+            pipeline_context_input='ctx string',
+            working_dir='dir here',
+            log_level=50
+        )
+
+
+def test_main_pass_with_defaults_context_flag():
     """Default values assigned - log 20 and cwd"""
     arg_list = ['blah',
                 '--context',
@@ -42,6 +86,76 @@ def test_main_pass_with_defaults():
         pipeline_context_input='ctx string',
         working_dir=os.getcwd(),
         log_level=20
+    )
+
+
+def test_main_pass_with_defaults_context_positional():
+    """Default values assigned - log 20 and cwd"""
+    arg_list = ['blah',
+                'ctx string']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        pypyr.cli.main(arg_list)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input='ctx string',
+        working_dir=os.getcwd(),
+        log_level=20
+    )
+
+
+def test_main_pass_with_context_flag_overrides_positional():
+    """Default values assigned - log 22 and dir set"""
+    arg_list = ['blah',
+                'ctx string',
+                '--log',
+                '22',
+                '--dir',
+                'arb',
+                '--context',
+                'from flag']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        pypyr.cli.main(arg_list)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input='from flag',
+        working_dir='arb',
+        log_level=22
+    )
+
+
+def test_main_pass_with_no_context():
+    """No context is None."""
+    arg_list = ['blah']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        pypyr.cli.main(arg_list)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input=None,
+        working_dir=os.getcwd(),
+        log_level=20
+    )
+
+
+def test_main_pass_with_no_context_other_flags_set():
+    """No context is None and other flag still work."""
+    arg_list = ['blah',
+                '--log',
+                '11']
+
+    with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+        pypyr.cli.main(arg_list)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input=None,
+        working_dir=os.getcwd(),
+        log_level=11
     )
 
 

--- a/tests/unit/pypyr/parser/list_test.py
+++ b/tests/unit/pypyr/parser/list_test.py
@@ -24,10 +24,12 @@ def test_empty_string_throw():
     with pytest.raises(AssertionError) as err_info:
         pypyr.parser.list.get_parsed_context(None)
 
+    print(repr(err_info.value))
     assert repr(err_info.value) == (
-        "AssertionError(\"pipeline must be invoked with --context set. For "
-        "this list parser you're looking for something like--context "
-        "'spam,eggs' or --context 'spam'.\",)")
+        "AssertionError(\"pipeline must be invoked with context arg set. For "
+        "this list parser you're looking for something like: "
+        "pypyr pipelinename 'spam,eggs' "
+        "OR: pypyr pipelinename 'spam'.\",)")
 
 
 def test_builtin_list_still_works():

--- a/tests/unit/pypyr/parser/string_test.py
+++ b/tests/unit/pypyr/parser/string_test.py
@@ -1,0 +1,36 @@
+"""string.py unit tests."""
+import pypyr.parser.string
+import pytest
+
+
+def test_comma_string_parses_to_dict():
+    """String input returns dictionary key argString."""
+    out = pypyr.parser.string.get_parsed_context('value 1,value 2, value3')
+    assert out['argString'] == 'value 1,value 2, value3'
+    assert len(out) == 1, "1 item expected"
+
+
+def test_no_commas_string_parses_to_single_entry():
+    """Special chars input string should return string as is."""
+    out = pypyr.parser.string.get_parsed_context(', value1 # value 2 & value3')
+    assert out['argString'] == ', value1 # value 2 & value3'
+    assert len(out) == 1, "1 item expected in context"
+
+
+def test_empty_string_throw():
+    """Empty input string should throw assert error."""
+    with pytest.raises(AssertionError) as err_info:
+        pypyr.parser.string.get_parsed_context(None)
+
+    assert repr(err_info.value) == (
+        "AssertionError(\"pipeline must be invoked with context arg set. For "
+        "this string parser you're looking for something "
+        "like: pypyr pipelinename 'spam and eggs'.\",)")
+
+
+def test_builtin_list_still_works():
+    """Don't break built-in string keyword."""
+    test_string = "arb string here"
+    assert test_string.upper() == "ARB STRING HERE"
+    assert test_string.count('arb') == 1
+    assert isinstance(test_string, str)

--- a/tests/unit/pypyr/steps/echo_test.py
+++ b/tests/unit/pypyr/steps/echo_test.py
@@ -62,7 +62,7 @@ def test_echo_empty_context_fails():
         pypyr.steps.echo.run_step(None)
 
     assert repr(err_info.value) == ("AssertionError(\"context must be set for "
-                                    "echo. Did you set --context 'echoMe=text "
+                                    "echo. Did you set 'echoMe=text "
                                     "here'?\",)")
 
 


### PR DESCRIPTION
- `pypyr pipelinename --context blah` is now `pypyr pipelinename blah`
- pypyr.parser.string simple string context parser
- rewire builtin echo pipeline to use pypyr.parser.string parser
- help and readme updates for --context removal