### PR TITLE
pypyr.steps.default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,6 +395,9 @@ Built-in steps
 |                               | expressions with {token} substitutions.         |                              |
 |                               |                                                 |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.default`_        | Set default values in context. Only set values  | defaults (dict)              |
+|                               | if they do not exist already.                   |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.echo`_           | Echo the context value `echoMe` to the output.  | echoMe (string)              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.env`_            | Get, set or unset $ENVs.                        | envGet (dict)                |
@@ -749,6 +752,62 @@ This will result in context like this:
 
 See a worked example `for contextsetf here
 <https://github.com/pypyr/pypyr-example/tree/master/pipelines/contextset.yaml>`__.
+
+pypyr.steps.default
+^^^^^^^^^^^^^^^^^^^
+Sets values in context if they do not exist already. Does not overwrite
+existing values. Supports nested hierarchies.
+
+This is especially useful for setting default values in context, for example
+when using `optional arguments
+<https://github.com/pypyr/pypyr-example/blob/master/pipelines/defaultarg.yaml>`__.
+from the shell.
+
+This step sets the contents of the context key *defaults* into context where
+keys in *defaults* do not exist in context already.
+The contents of the *defaults* key must be a dictionary.
+
+Example:
+Given a context like this:
+
+.. code-block:: yaml
+
+    key1: value1
+    key2:
+        key2.1: value2.1
+    key3: None
+
+And *defaults* input like this:
+
+.. code-block:: yaml
+
+    key1: updated value here won't overwrite since it already exists
+    key2:
+        key2.2: value2.2
+    key3: key 3 exists so I won't overwrite
+
+Will result in context:
+
+.. code-block:: yaml
+
+    key1: value1
+    key2:
+        key2.1: value2.1
+        key2.2: value2.2
+    key3: None
+
+By comparison, the *in* step decorator, and the steps *contextset*,
+*contextsetf* and *contextmerge* overwrite values that are in context already.
+
+The recursive if-not-exists-then-set check happens for dictionaries, but not
+for items in Lists, Sets and Tuples. You can set default values of type List,
+Set or Tuple if their keys don't exist in context already, but this step will
+not recurse through the List, Set or Tuple itself.
+
+Supports `Substitutions`_. String interpolation applies to keys and values.
+
+See a worked example for `default here
+<https://github.com/pypyr/pypyr-example/blob/master/pipelines/default.yaml>`__.
 
 pypyr.steps.echo
 ^^^^^^^^^^^^^^^^

--- a/pypyr/log/logger.py
+++ b/pypyr/log/logger.py
@@ -5,12 +5,6 @@ Configuration for the python logging library.
 import logging
 
 
-def get_logger(logger_name):
-    """Create a logger with the log_level set."""
-    logger = logging.getLogger(logger_name)
-    return logger
-
-
 def set_logging_config(log_level):
     """Set python logging library config.
 

--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -4,14 +4,13 @@ Load modules dynamically, find things on file-system.
 """
 
 import importlib
+import logging
 import os
-from pypyr.errors import PipelineNotFoundError, PyModuleNotFoundError
-import pypyr.log.logger
 import sys
-
+from pypyr.errors import PipelineNotFoundError, PyModuleNotFoundError
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_module(module_abs_import):

--- a/pypyr/parser/commas.py
+++ b/pypyr/parser/commas.py
@@ -6,10 +6,10 @@ becomes the key, with value to true.
 So a string like this "ham,eggs,bacon", will yield:
 {'ham': True, 'eggs': True, 'bacon': True}
 """
-import pypyr.log.logger
+import logging
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(context_arg):

--- a/pypyr/parser/json.py
+++ b/pypyr/parser/json.py
@@ -1,10 +1,10 @@
 """Context parser that returns a dictionary from a json string."""
 
-import pypyr.log.logger
+import logging
 import json
 
 # use pypyrlogger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(context_arg):

--- a/pypyr/parser/jsonfile.py
+++ b/pypyr/parser/jsonfile.py
@@ -1,10 +1,10 @@
 """Context parser that returns a dictionary from a local json file."""
 
-import pypyr.log.logger
+import logging
 import json
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(context_arg):

--- a/pypyr/parser/keyvaluepairs.py
+++ b/pypyr/parser/keyvaluepairs.py
@@ -9,10 +9,10 @@ will result in a context key name of ' k2' not 'k2'.
 So a string like this "pig=ham,hen=eggs,yummypig=bacon", will yield:
 {'pig': 'ham', 'hen': ''eggs', 'yummypig': 'bacon'}
 """
-import pypyr.log.logger
+import logging
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(context_arg):

--- a/pypyr/parser/list.py
+++ b/pypyr/parser/list.py
@@ -5,10 +5,10 @@ Takes a comma delimited string and returns a list named argList.
 So a string like this "ham,eggs,bacon", will yield context:
 { 'argList': ['ham', 'eggs', 'bacon']}
 """
-import pypyr.log.logger
+import logging
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(context_arg):

--- a/pypyr/parser/yamlfile.py
+++ b/pypyr/parser/yamlfile.py
@@ -1,11 +1,11 @@
 """Context parser that returns a dictionary from a local yaml file."""
 
 from collections.abc import MutableMapping
-import pypyr.log.logger
+import logging
 import ruamel.yaml as yaml
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(context_arg):

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -3,6 +3,7 @@
 Runs the pipeline specified by the input pipeline_name parameter.
 Pipelines must have a "steps" list-like attribute.
 """
+import logging
 import pypyr.context
 import pypyr.log.logger
 import pypyr.moduleloader
@@ -10,7 +11,7 @@ import pypyr.stepsrunner
 import ruamel.yaml as yaml
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_parsed_context(pipeline, context_in_string):

--- a/pypyr/steps/contextclear.py
+++ b/pypyr/steps/contextclear.py
@@ -4,10 +4,10 @@ This is handy if you run the same step multiple times in a pipeline and you
 don't want the previously assigned context settings for that step to impact the
 next iteration.
 """
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/contextclearall.py
+++ b/pypyr/steps/contextclearall.py
@@ -1,9 +1,8 @@
 """pypyr step that wipes the entire context."""
-import pypyr.context
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/contextset.py
+++ b/pypyr/steps/contextset.py
@@ -7,10 +7,10 @@ create a new key (or update existing key) with that value.
 So let's say you already have context['currentKey'] = 'eggs'.
 If you run newKey: currentKey, you'll end up with context['newKey'] == 'eggs'
 """
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/default.py
+++ b/pypyr/steps/default.py
@@ -1,0 +1,84 @@
+"""pypyr step that sets default values in context.
+
+Sets values in context if they do not exist already. Does not overwrite
+existing values. Supports nested hierarchies.
+
+Example:
+Given a context like this:
+    key1: value1
+    key2:
+        key2.1: value2.1
+    key3: None
+
+And defaults input like this:
+    key1: 'updated value here won't overwrite since it already exists'
+    key2:
+        key2.2: value2.2
+    key3: 'key 3 exists so I won't overwrite
+
+Will result in context:
+    key1: value1
+    key2:
+        key2.1: value2.1
+        key2.2: value2.2
+    key3: None
+
+By comparison, the in step decorator, contextset, contextsetf and contextmerge
+overwrite values that are in context already.
+
+Applies string interpolation as it adds. String interpolation applies to keys
+and values.
+"""
+import logging
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Set hierarchy into context with substitutions if it doesn't exist yet.
+
+    context is a dictionary or dictionary-like.
+    context['defaults'] must exist. It's a dictionary.
+
+    Will iterate context['defaults'] and add these as new values where
+    their keys don't already exist. While it's doing so, it will leave
+    all other values in the existing hierarchy untouched.
+
+    List merging is purely additive, with no checks for uniqueness or already
+    existing list items. E.g context [0,1,2] with contextMerge=[2,3,4]
+    will result in [0,1,2,2,3,4]
+
+    Keep this in mind especially where complex types like
+    dicts nest inside a list - a merge will always add a new dict list item,
+    not merge it into whatever dicts might exist on the list already.
+
+    For example, say input context is:
+        key1: value1
+        key2: value2
+        key3:
+            k31: value31
+            k32: value32
+        defaults:
+            key2: 'aaa_{key1}_zzz'
+            key3:
+                k33: value33
+            key4: 'bbb_{key2}_yyy'
+
+    This will result in return context:
+        key1: value1
+        key2: value2
+        key3:
+            k31: value31
+            k32: value32
+            k33: value33
+        key4: bbb_value2_yyy
+    """
+    logger.debug("started")
+    context.assert_key_has_value(key='defaults', caller=__name__)
+
+    context.set_defaults(context['defaults'])
+
+    logger.info(f"set {len(context['defaults'])} context item defaults.")
+
+    logger.debug("done")

--- a/pypyr/steps/echo.py
+++ b/pypyr/steps/echo.py
@@ -1,8 +1,8 @@
 """Step that echos simple input back to logger."""
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/env.py
+++ b/pypyr/steps/env.py
@@ -1,9 +1,9 @@
 """Step that gets, sets and unsets env vars."""
 import os
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/fetchjson.py
+++ b/pypyr/steps/fetchjson.py
@@ -1,9 +1,9 @@
 """pypyr step that loads json file into context."""
 import json
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/fetchyaml.py
+++ b/pypyr/steps/fetchyaml.py
@@ -1,10 +1,10 @@
 """pypyr step that loads yaml file into context."""
 from collections.abc import MutableMapping
-import pypyr.log.logger
+import logging
 import ruamel.yaml as yaml
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/fileformat.py
+++ b/pypyr/steps/fileformat.py
@@ -1,9 +1,9 @@
 """pypyr step that parses file for string substitutions and writes output."""
 import os
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/fileformatjson.py
+++ b/pypyr/steps/fileformatjson.py
@@ -1,10 +1,10 @@
 """pypyr step that parses json file for string substitutions, writes output."""
 import os
 import json
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/fileformatyaml.py
+++ b/pypyr/steps/fileformatyaml.py
@@ -1,10 +1,10 @@
 """pypyr step that parses yaml for string substitutions, writes output."""
 import os
-import pypyr.log.logger
+import logging
 import ruamel.yaml as yaml
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/filereplace.py
+++ b/pypyr/steps/filereplace.py
@@ -1,10 +1,10 @@
 """pypyr step that parses file, does string replacement and writes output."""
 from functools import reduce
 import os
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/py.py
+++ b/pypyr/steps/py.py
@@ -2,10 +2,10 @@
 
 Uses python's exec() to evaluate and execute arbitrary python code.
 """
-import pypyr.log.logger
+import logging
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/pypyrversion.py
+++ b/pypyr/steps/pypyrversion.py
@@ -1,9 +1,9 @@
 """Step that echos pypyr version."""
-import pypyr.log.logger
+import logging
 import pypyr.version
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/safeshell.py
+++ b/pypyr/steps/safeshell.py
@@ -4,11 +4,11 @@ You cannot use things like exit, return, shell pipes, filename wildcards,
 environment,variable expansion, and expansion of ~ to a user’s home
 directory.
 """
-import pypyr.log.logger
+import logging
 import subprocess
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/shell.py
+++ b/pypyr/steps/shell.py
@@ -4,11 +4,11 @@ The context['cmd'] string must be formatted exactly as it would be when typed
 at the shell prompt. This includes, for example, quoting or backslash escaping
 filenames with spaces in them. The shell defaults to /bin/sh.
 """
-import pypyr.log.logger
+import logging
 import subprocess
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/steps/tar.py
+++ b/pypyr/steps/tar.py
@@ -1,10 +1,10 @@
 """Archive and extract tars."""
-import pypyr.log.logger
-from pypyr.errors import KeyNotInContextError
+import logging
 import tarfile
+from pypyr.errors import KeyNotInContextError
 
 # logger means the log level will be set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_step(context):

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -3,11 +3,11 @@
 pipelinerunner uses this to parse and run steps.
 """
 
-import pypyr.log.logger
+import logging
 import pypyr.moduleloader
 
 # use pypyr logger to ensure loglevel is set correctly
-logger = pypyr.log.logger.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_pipeline_steps(pipeline, steps_group):

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -1400,3 +1400,180 @@ def test_merge_pass_nested_with_types():
 
 
 # ------------------- merge --------------------------------------------------#
+
+# ------------------- set_defaults -------------------------------------------#
+def test_set_defaults_pass_no_substitutions():
+    """defaults success case with no substitutions."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+    })
+
+    add_me = {
+        'key2': 'value4',
+        'key4': 'value5'
+    }
+
+    context.set_defaults(add_me)
+
+    assert context['key1'] == 'value1'
+    # since key2 exists already, shouldn't update
+    assert context['key2'] == 'value2'
+    assert context['key3'] == 'value3'
+    assert context['key4'] == 'value5'
+
+
+def test_set_defaults_pass_nested_with_substitutions():
+    """merge success case with nested hierarchy and substitutions."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': {
+            'k31': 'value31',
+            'k32': 'value32',
+        }})
+
+    add_me = {
+        'key2': 'value4',
+        'key3': {
+            'k33': 'value33'
+        },
+        'key4': '444_{key1}_444'
+    }
+
+    context.set_defaults(add_me)
+
+    assert context == {
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': {
+            'k31': 'value31',
+            'k32': 'value32',
+            'k33': 'value33'
+        },
+        'key4': '444_value1_444'
+    }
+
+
+def test_set_defaults_pass_nested_with_types():
+    """defaults with nested hierarchy, substitutions, diff types."""
+    context = Context({
+        'k1': 'v1',
+        'k2': 'v2_{ctx1}',
+        'k3': bytes('v3{ctx1}', encoding='utf-8'),
+        'k4': [
+            1,
+            2,
+            '3_{ctx4}here',
+            {'key4.1': 'value4.1',
+             '{ctx2}_key4.2': 'value_{ctx3}_4.2',
+             'key4.3': {
+                              '4.3.1': '4.3.1value',
+                              '4.3.2': '4.3.2_{ctx1}_value'}}
+        ],
+        'k5': {'key5.1': {'kv511': 'value5.1'}, 'key5.2': 'value5.2'},
+        'k6': ('six6.1', False, [0, 1, 2], 77, 'six_{ctx1}_end'),
+        'k7': 'simple string to close 7',
+        'k8': ('tuple1', 'tuple2'),
+        'k9': {'set1', 'set2'},
+        'k10': (
+            1,
+            2,
+            {'10.1': '10.1v',
+             '10.2': '{10.2v}',
+             },
+            3),
+        'k11': {
+            'k11.1': '11.1v',
+            'k11.2': {
+                'k11.2.1': '11.2.1v',
+                'k11.2.2': {
+                    'k11.2.2.1': '11.2.2.1v'
+                },
+            },
+        },
+        'k12': 'end'
+    }
+    )
+
+    add_me = {
+        'k4': [
+            4.4,
+            {'key4.3': {
+                '4.3.1': 'merged value for 4.3.1'
+            }
+            }
+        ],
+        'k5': {
+            'key5.1': {
+                'kv522': 'kv522 from merge {k1}'
+            }},
+        'k8': ('tuple3', ),
+        'k9': {'set3', },
+        'k10': ({
+            '{k1}': [0,
+                     1,
+                     2,
+                     (
+                         'tuple in list in dict in tuple in dict',
+                         'hello {k2}',
+                         {'k1': '{k1}'}
+                     ),
+                     [0, 1, 2, '{k1}', 3, (True, False), ['00', '{k1}']],
+                     4]
+        },
+            4),
+        'k11': {
+            'k11.2': {
+                'k11.2.2': {
+                    'add me': '{k1}'
+                },
+            },
+        },
+    }
+
+    context.set_defaults(add_me)
+
+    assert context == {
+        'k1': 'v1',
+        'k2': 'v2_{ctx1}',
+        'k3': bytes('v3{ctx1}', encoding='utf-8'),
+        'k4': [
+            1,
+            2,
+            '3_{ctx4}here',
+            {'key4.1': 'value4.1',
+             '{ctx2}_key4.2': 'value_{ctx3}_4.2',
+             'key4.3': {
+                              '4.3.1': '4.3.1value',
+                              '4.3.2': '4.3.2_{ctx1}_value'}}
+        ],
+        'k5': {'key5.1': {'kv511': 'value5.1',
+                          'kv522': 'kv522 from merge v1'},
+               'key5.2': 'value5.2'},
+        'k6': ('six6.1', False, [0, 1, 2], 77, 'six_{ctx1}_end'),
+        'k7': 'simple string to close 7',
+        'k8': ('tuple1', 'tuple2'),
+        'k9': {'set1', 'set2'},
+        'k10': (
+            1,
+            2,
+            {'10.1': '10.1v',
+             '10.2': '{10.2v}',
+             },
+            3),
+        'k11': {
+            'k11.1': '11.1v',
+            'k11.2': {
+                'k11.2.1': '11.2.1v',
+                'k11.2.2': {
+                    'k11.2.2.1': '11.2.2.1v',
+                    'add me': 'v1'
+                },
+            },
+        },
+        'k12': 'end'
+    }
+
+# ------------------- set_defaults -------------------------------------------#

--- a/tests/unit/pypyr/steps/contextmerge_test.py
+++ b/tests/unit/pypyr/steps/contextmerge_test.py
@@ -1,10 +1,10 @@
 """contextmerge.py unit tests."""
+import logging
+import pytest
 from pypyr.context import Context
 from pypyr.errors import KeyNotInContextError
-import pypyr.log.logger
 from unittest.mock import patch
 import pypyr.steps.contextmerge
-import pytest
 
 
 def test_contextmerge_throws_on_empty_context():
@@ -57,7 +57,7 @@ def test_contextmerge_pass_different_types_with_log():
         }
     })
 
-    logger = pypyr.log.logger.get_logger('pypyr.steps.contextmerge')
+    logger = logging.getLogger('pypyr.steps.contextmerge')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.contextmerge.run_step(context)
 

--- a/tests/unit/pypyr/steps/contextmerge_test.py
+++ b/tests/unit/pypyr/steps/contextmerge_test.py
@@ -1,9 +1,9 @@
 """contextmerge.py unit tests."""
 import logging
 import pytest
+from unittest.mock import patch
 from pypyr.context import Context
 from pypyr.errors import KeyNotInContextError
-from unittest.mock import patch
 import pypyr.steps.contextmerge
 
 

--- a/tests/unit/pypyr/steps/default_test.py
+++ b/tests/unit/pypyr/steps/default_test.py
@@ -1,0 +1,88 @@
+"""default.py unit tests."""
+import logging
+import pytest
+from unittest.mock import patch
+from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
+import pypyr.steps.default
+
+
+def test_contextdefault_throws_on_empty_context():
+    """context must exist."""
+    with pytest.raises(KeyNotInContextError):
+        pypyr.steps.default.run_step(Context())
+
+
+def test_contextdefault_throws_on_contextdefault_missing():
+    """contextMerge must exist in context."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.default.run_step(Context({'arbkey': 'arbvalue'}))
+
+    assert repr(err_info.value) == (
+        "KeyNotInContextError(\"context['defaults'] "
+        "doesn't exist. It must exist for "
+        "pypyr.steps.default.\",)")
+
+
+def test_contextdefault_pass_no_substitutions():
+    """contextdefault success case with no substitutions."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'defaults': {
+            'key2': 'value4',
+            'key4': 'value5'
+        }
+    })
+
+    pypyr.steps.default.run_step(context)
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'value2'
+    assert context['key3'] == 'value3'
+    assert context['key4'] == 'value5'
+
+
+def test_contextdefault_pass_different_types_with_log():
+    """contextdefault success case with substitutions of non strings."""
+    context = Context({
+        'k1': 33,
+        'k2': 123.45,
+        'k3': False,
+        'defaults': {
+            'kint': '{k1}',
+            'kfloat': '{k2}',
+            'kbool': '{k3}'
+        }
+    })
+
+    logger = logging.getLogger('pypyr.steps.default')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.default.run_step(context)
+
+    mock_logger_info.assert_called_once_with('set 3 context item defaults.')
+
+    assert context['kint'] == '33'
+    assert context['k1'] == 33
+    assert context['kfloat'] == '123.45'
+    assert context['k2'] == 123.45
+    assert context['kbool'] == 'False'
+    assert not context['k3']
+
+
+def test_contextdefault_list():
+    """Simple list"""
+    context = Context({'ctx1': 'ctxvalue1',
+                       'ctx2': 'ctxvalue2',
+                       'ctx3': 'ctxvalue3',
+                       'defaults': {
+                           'ctx4': ['k1', 'k2', '{ctx3}', True, False, 44]
+                       }})
+
+    pypyr.steps.default.run_step(context)
+
+    assert context['ctx1'] == 'ctxvalue1'
+    assert context['ctx2'] == 'ctxvalue2'
+    assert context['ctx3'] == 'ctxvalue3'
+    assert context['ctx4'] == ['k1', 'k2', 'ctxvalue3', True, False, 44]

--- a/tests/unit/pypyr/steps/echo_test.py
+++ b/tests/unit/pypyr/steps/echo_test.py
@@ -1,9 +1,9 @@
 """echo.py unit tests."""
+import logging
+import pytest
 from pypyr.context import Context
 from pypyr.errors import KeyNotInContextError
-import pypyr.log.logger
 import pypyr.steps.echo
-import pytest
 from unittest.mock import patch
 
 
@@ -12,7 +12,7 @@ def test_echo_pass():
     context = Context({
         'echoMe': 'test value here'})
 
-    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    logger = logging.getLogger('pypyr.steps.echo')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.echo.run_step(context)
 
@@ -25,7 +25,7 @@ def test_echo_substitutions_pass():
         'key1': 'down the',
         'echoMe': 'piping {key1} valleys wild'})
 
-    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    logger = logging.getLogger('pypyr.steps.echo')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.echo.run_step(context)
 
@@ -37,7 +37,7 @@ def test_echo_number_pass():
     context = Context({
         'echoMe': 77})
 
-    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    logger = logging.getLogger('pypyr.steps.echo')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.echo.run_step(context)
 
@@ -49,7 +49,7 @@ def test_echo_bool_pass():
     context = Context({
         'echoMe': False})
 
-    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    logger = logging.getLogger('pypyr.steps.echo')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.echo.run_step(context)
 
@@ -81,7 +81,7 @@ def test_echo_missing_echo_me_raises():
 def test_echo_echo_me_none_pass():
     """Echo can output None."""
     context = Context({'echoMe': None})
-    logger = pypyr.log.logger.get_logger('pypyr.steps.echo')
+    logger = logging.getLogger('pypyr.steps.echo')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.echo.run_step(context)
 

--- a/tests/unit/pypyr/steps/pypyrversion_test.py
+++ b/tests/unit/pypyr/steps/pypyrversion_test.py
@@ -12,9 +12,10 @@ def test_pypyr_version():
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.steps.pypyrversion.run_step({})
 
-    mock_logger_info.assert_any_call('pypyr version is: '
-                                     f'pypyr {pypyr.version.__version__} '
-                                     f'python {platform.python_version()}')
+    mock_logger_info.assert_called_once_with(
+        'pypyr version is: '
+        f'pypyr {pypyr.version.__version__} '
+        f'python {platform.python_version()}')
 
 
 def test_pypyr_version_context_out_same_as_in():

--- a/tests/unit/pypyr/steps/pypyrversion_test.py
+++ b/tests/unit/pypyr/steps/pypyrversion_test.py
@@ -1,11 +1,20 @@
 """pypyrversion.py unit tests."""
+import logging
+import platform
+from unittest.mock import patch
 from pypyr.context import Context
-import pypyr.log.logger
 import pypyr.steps.pypyrversion
+import pypyr.version
 
 
 def test_pypyr_version():
-    pypyr.steps.pypyrversion.run_step({})
+    logger = logging.getLogger('pypyr.steps.pypyrversion')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.pypyrversion.run_step({})
+
+    mock_logger_info.assert_any_call('pypyr version is: '
+                                     f'pypyr {pypyr.version.__version__} '
+                                     f'python {platform.python_version()}')
 
 
 def test_pypyr_version_context_out_same_as_in():

--- a/tests/unit/pypyr/stepsrunner_test.py
+++ b/tests/unit/pypyr/stepsrunner_test.py
@@ -1,9 +1,10 @@
 """stepsrunner.py unit tests."""
+import logging
+import pytest
+from unittest.mock import call, patch
 from pypyr.context import Context
 from pypyr.errors import ContextError
 import pypyr.stepsrunner
-import pytest
-from unittest.mock import call, patch
 
 # ------------------------- test context--------------------------------------#
 
@@ -82,7 +83,7 @@ def mock_run_step_none_context(context):
 
 def test_get_pipeline_steps_pass():
     """Return named step group from pipeline"""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         steps = pypyr.stepsrunner.get_pipeline_steps(
             get_test_pipeline(), 'sg1')
@@ -99,7 +100,7 @@ def test_get_pipeline_steps_pass():
 
 def test_get_pipeline_steps_not_found():
     """Can't find step group in pipeline"""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         steps = pypyr.stepsrunner.get_pipeline_steps(
             get_test_pipeline(), 'arb')
@@ -112,7 +113,7 @@ def test_get_pipeline_steps_not_found():
 
 def test_get_pipeline_steps_none():
     """Find step group in pipeline but it has no steps"""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'warn') as mock_logger_warn:
         steps = pypyr.stepsrunner.get_pipeline_steps(
             get_test_pipeline(), 'sg4')
@@ -182,7 +183,7 @@ def test_run_failure_step_group_pass():
 
 def test_run_failure_step_group_swallows():
     """Failure step group runner swallows errors."""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
 
     with patch('pypyr.stepsrunner.run_step_group') as mock_run_group:
         with patch.object(logger, 'error') as mock_logger_error:
@@ -283,7 +284,7 @@ def test_run_pipeline_step_none_context(mocked_moduleloader):
 
 def test_run_pipeline_steps_none():
     """If steps None does nothing"""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(None, Context({'k1': 'v1'}))
 
@@ -293,7 +294,7 @@ def test_run_pipeline_steps_none():
 @patch('pypyr.stepsrunner.run_pipeline_step')
 def test_run_pipeline_steps_complex(mock_run_step):
     """Complex step run with no in args."""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(
             [{'name': 'step1'}], Context({'k1': 'v1'}))
@@ -319,7 +320,7 @@ def test_run_pipeline_steps_complex_with_in(mock_run_step):
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -352,7 +353,7 @@ def test_run_pipeline_steps_complex_with_run_true(mock_run_step):
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -386,7 +387,7 @@ def test_run_pipeline_steps_complex_with_run_false(mock_run_step):
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -411,7 +412,7 @@ def test_run_pipeline_steps_complex_with_run_str_formatting_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -436,7 +437,7 @@ def test_run_pipeline_steps_complex_with_run_str_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -461,7 +462,7 @@ def test_run_pipeline_steps_complex_with_run_str_lower_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -486,7 +487,7 @@ def test_run_pipeline_steps_complex_with_run_bool_formatting_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -511,7 +512,7 @@ def test_run_pipeline_steps_complex_with_run_bool_formatting_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -547,7 +548,7 @@ def test_run_pipeline_steps_complex_with_run_string_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -583,7 +584,7 @@ def test_run_pipeline_steps_complex_with_run_1_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -619,7 +620,7 @@ def test_run_pipeline_steps_complex_with_run_99_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -655,7 +656,7 @@ def test_run_pipeline_steps_complex_with_run_neg1_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -699,7 +700,7 @@ def test_run_pipeline_steps_mix_run_and_not_run(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         with patch.object(logger, 'info') as mock_logger_info:
             pypyr.stepsrunner.run_pipeline_steps(steps, context)
@@ -768,7 +769,7 @@ def test_run_pipeline_steps_complex_with_multistep_none_run(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -799,7 +800,7 @@ def test_run_pipeline_steps_complex_with_skip_false(mock_run_step):
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -833,7 +834,7 @@ def test_run_pipeline_steps_complex_with_skip_true(mock_run_step):
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -858,7 +859,7 @@ def test_run_pipeline_steps_complex_with_skip_str_formatting_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -883,7 +884,7 @@ def test_run_pipeline_steps_complex_with_skip_str_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -908,7 +909,7 @@ def test_run_pipeline_steps_complex_with_skip_str_lower_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -934,7 +935,7 @@ def test_run_pipeline_steps_complex_with_run_and_skip_bool_formatting_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -959,7 +960,7 @@ def test_run_pipeline_steps_complex_with_skip_bool_formatting_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -995,7 +996,7 @@ def test_run_pipeline_steps_complex_with_skip_string_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1031,7 +1032,7 @@ def test_run_pipeline_steps_complex_with_skip_0_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1067,7 +1068,7 @@ def test_run_pipeline_steps_complex_with_skip_99_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1092,7 +1093,7 @@ def test_run_pipeline_steps_complex_with_skip_neg1_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1125,7 +1126,7 @@ def test_run_pipeline_steps_mix_skip_and_not_skip(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         with patch.object(logger, 'info') as mock_logger_info:
             pypyr.stepsrunner.run_pipeline_steps(steps, context)
@@ -1200,7 +1201,7 @@ def test_run_pipeline_steps_complex_with_multistep_all_skip(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1234,7 +1235,7 @@ def test_run_pipeline_steps_complex_swallow_true(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1269,7 +1270,7 @@ def test_run_pipeline_steps_complex_swallow_false(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1305,7 +1306,7 @@ def test_run_pipeline_steps_complex_swallow_true_error(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         with patch.object(logger, 'error') as mock_logger_error:
             pypyr.stepsrunner.run_pipeline_steps(steps, context)
@@ -1422,7 +1423,7 @@ def test_run_pipeline_steps_swallow_sequence(
     context = get_test_context()
     original_len = len(context)
 
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         with patch.object(logger, 'info') as mock_logger_info:
             with patch.object(logger, 'error') as mock_logger_error:
@@ -1509,7 +1510,7 @@ def test_run_pipeline_steps_swallow_sequence(
 @patch('pypyr.stepsrunner.run_pipeline_step')
 def test_run_pipeline_steps_simple(mock_run_step):
     """Simple step run."""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(['step1'], {'k1': 'v1'})
 
@@ -1522,7 +1523,7 @@ def test_run_pipeline_steps_simple(mock_run_step):
        side_effect=ValueError('arb error here'))
 def test_run_pipeline_steps_simple_with_error(mock_run_step):
     """Simple step run with error should not swallow."""
-    logger = pypyr.log.logger.get_logger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.stepsrunner')
     with patch.object(logger, 'debug') as mock_logger_debug:
         with pytest.raises(ValueError) as err_info:
             pypyr.stepsrunner.run_pipeline_steps(['step1'], {'k1': 'v1'})


### PR DESCRIPTION
- add new step pypyr.steps.default for setting default values in context
- remove custom `pypyr.log.logger.get_logger`. all code now uses standard python `logging.getLogger`.
- better unit testing for pypyrversion
- version bump
