### PR TITLE
foreach

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,12 +329,22 @@ Don't bother specifying these unless you want to deviate from the default values
       in: # optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
         parameter1: value1
         parameter2: value2
+      foreach: [] # optional. Repeat the step once for each item in this list. By default step executes once.
       run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
       skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
       swallow: False # optional. Swallows any errors raised by the step. Defaults to False if not specified.
 
 +---------------+----------+---------------------------------------------+----------------+
 | **decorator** | **type** | **description**                             | **default**    |
++---------------+----------+---------------------------------------------+----------------+
+| foreach       | list     | Run the step once for each item in the list.| None           |
+|               |          | The iterator is context['i'].               |                |
+|               |          |                                             |                |
+|               |          | The *run*, *skip* & *swallow* decorators    |                |
+|               |          | evaluate dynamically on each iteration.     |                |
+|               |          | So if during an iteration the step's logic  |                |
+|               |          | sets ``run=False``, the step will not       |                |
+|               |          | execute on the next iteration.              |                |
 +---------------+----------+---------------------------------------------+----------------+
 | in            | dict     | Add this to the context so that this        | None           |
 |               |          | step and subsequent steps can use these     |                |
@@ -370,6 +380,13 @@ None/Empty, 0,'', [], {} will be False.
 
 See a worked example for `step decorators here
 <https://github.com/pypyr/pypyr-example/blob/master/pipelines/stepdecorators.yaml>`__.
+
+See a worked example of the looping `foreach decorator here
+<https://github.com/pypyr/pypyr-example/blob/master/pipelines/foreach.yaml>`__.
+
+Here is an example of `foreach dynamic decorator evaluation
+<https://github.com/pypyr/pypyr-example/blob/master/pipelines/foreachconditionals.yaml>`__.
+
 
 Built-in steps
 --------------

--- a/README.rst
+++ b/README.rst
@@ -541,26 +541,6 @@ Number equality with substitutions:
     assertThis: '{numberOne}'
     assertEquals: '{numberTwo}' # substituted numbers not equal. Stop pipeline.
 
-GOTCHA:
-  A string formatting expression like ``{numberOne}`` will always return
-  a string. This means a comparison to a number type will fail even if it looks
-  like the same number.
-
-  .. code-block:: yaml
-
-    meaningOfLife: 42
-    assertThis: '{meaningOfLife}'
-    assertEquals: 42 # stop pipeline. '42' != 42 (str vs int)
-
-  vs
-
-  .. code-block:: yaml
-
-    meaningOfLife: 42
-    assertThis: '{meaningOfLife}'
-    assertEquals: '42' # continue pipeline. '42' == '42' (str vs str)
-
-
 Complex types:
 
 .. code-block:: yaml

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -201,14 +201,12 @@ class Context(dict):
         if isinstance(val, str):
             try:
                 return self.get_processed_string(val)
-            except KeyError as err:
+            except KeyNotInContextError as err:
                 # Wrapping the KeyError into a less cryptic error for end-user
                 # friendliness
-                missing_key = err.args[0]
                 raise KeyNotInContextError(
-                    f'Unable to format \'{val}\' at context[\'{key}\'] with '
-                    f'{{{missing_key}}}, because '
-                    f'context[\'{missing_key}\'] doesn\'t exist'
+                    f'Unable to format \'{val}\' at context[\'{key}\'], '
+                    f'because {err}'
                 ) from err
         else:
             # any sort of complex type will work with get_formatted_iterable.
@@ -306,14 +304,12 @@ class Context(dict):
         if isinstance(input_string, str):
             try:
                 return self.get_processed_string(input_string)
-            except KeyError as err:
+            except KeyNotInContextError as err:
                 # Wrapping the KeyError into a less cryptic error for end-user
                 # friendliness
-                missing_key = err.args[0]
                 raise KeyNotInContextError(
-                    f'Unable to format \'{input_string}\' with '
-                    f'{{{missing_key}}}, because '
-                    f'context[\'{missing_key}\'] doesn\'t exist') from err
+                    f'Unable to format \'{input_string}\' because {err}'
+                ) from err
         else:
             raise TypeError(f"can only format on strings. {input_string} is a "
                             f"{type(input_string)} instead.")
@@ -393,7 +389,7 @@ class Context(dict):
         if input_string[: 6] == '[sic]"':
             return input_string[6: -1]
         else:
-            return input_string.format(**self)
+            return input_string.format_map(self)
 
     def iter_formatted_strings(self, iterable_strings):
         """Generator that yields a formatted string from iterable_strings

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -1,6 +1,7 @@
 """pypyr context class. Dictionary ahoy."""
 from collections import namedtuple
 from collections.abc import Mapping, Set, Sequence
+from string import Formatter
 from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
 from pypyr.utils import types
 
@@ -10,6 +11,12 @@ ContextItemInfo = namedtuple('ContextItemInfo',
                               'expected_type',
                               'is_expected_type',
                               'has_value'])
+
+# I *think* instantiating formatter at module level is fine - far as I can see
+# the class methods are functional, not dependant on class state (also, no
+# __init__).
+# https://github.com/python/cpython/blob/master/Lib/string.py
+formatter = Formatter()
 
 
 class Context(dict):
@@ -334,11 +341,11 @@ class Context(dict):
 
         if isinstance(value, str):
             result = self.get_formatted_string(value)
-
-            if out_type is str:
+            result_type = type(result)
+            if out_type is result_type:
                 # get_formatted_string result is already a string
                 return result
-            elif out_type is bool:
+            elif out_type is bool and result_type is str:
                 # casting a str to bool is always True, hence special case. If
                 # the str value is 'False'/'false', presumably user can
                 # reasonably expect a bool False response.
@@ -360,6 +367,16 @@ class Context(dict):
         If input_string='Piping {key1} the {key2} wild'
         And context={'key1': 'down', 'key2': 'valleys', 'key3': 'value3'}
 
+        An input string with a single formatting expression and nothing else
+        will return the object at that context path: input_string='{key1}'.
+        This means that the return obj will be the same type as the source
+        object. This return object in itself has token substitions run on it
+        iteratively.
+
+        By comparison, multiple formatting expressions and/or the inclusion of
+        literal text will result in a string return type:
+        input_string='{key1} literal text {key2}'
+
         Then this will return string: "Piping down the valleys wild"
 
         If a string is NOT to have {substitutions} run on it, it's sic erat
@@ -378,9 +395,11 @@ class Context(dict):
             input_string: string to Parse
 
         Returns:
-            str: Formatted string with {substitutions} made from context. If
-            it's a [sic] string, x from [sic]"x", with no substitutions made on
-            x.
+            any given type: Formatted string with {substitutions} made from
+            context. If it's a [sic] string, x from [sic]"x", with no
+            substitutions made on x. If input_string was a single expression
+            (e.g '{field}'), then returns the object with {substitutions} made
+            for its attributes.
 
         Raises:
             KeyNotInContextError: input_string is not a sic string and has
@@ -390,7 +409,43 @@ class Context(dict):
         if input_string[: 6] == '[sic]"':
             return input_string[6: -1]
         else:
-            return input_string.format_map(self)
+            print(f"doing input: {input_string}")
+
+            # is this a special one field formatstring? i.e "{field}", with
+            # nothing else?
+            out = None
+            is_out_set = False
+            expr_count = 0
+            # parse finds field format expressions and/or literals in input
+            for expression in formatter.parse(input_string):
+                # parse tuple:
+                # (literal_text, field_name, format_spec, conversion)
+                # it's a single '{field}' if no literal_text but field_name
+                # no literal, field name exists, and no previous expr found
+                if (not expression[0] and expression[1] and not expr_count):
+                    # get_field tuple: (obj, used_key)
+                    out = formatter.get_field(expression[1], None, self)[0]
+                    # second flag necessary because a literal with no format
+                    # expression will still result in expr_count == 1
+                    is_out_set = True
+                    print(f"just set out: {out}")
+
+                expr_count += 1
+
+                # this is a little bit clumsy, but you have to consume the
+                # iterator to get the count. Interested in 1 and only 1 field
+                # expressions with no literal text: have to loop to see if
+                # there is >1.
+                if expr_count > 1:
+                    break
+
+            print(f"expression count: {expr_count}")
+            if is_out_set and expr_count == 1:
+                # found 1 and only 1. but this could be an iterable obj
+                # that needs formatting rules run on it in itself
+                return self.get_formatted_iterable(out)
+            else:
+                return input_string.format_map(self)
 
     def iter_formatted_strings(self, iterable_strings):
         """Generator that yields a formatted string from iterable_strings

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -297,8 +297,8 @@ class Context(dict):
             Formatted string.
 
         Raises:
-            KeyError: context[key] has {somekey} where somekey does not exist
-                      in context dictionary.
+            KeyNotInContextError: context[key] has {somekey} where somekey does
+                                  not exist in context dictionary.
             TypeError: Attempt operation on a non-string type.
         """
         if isinstance(input_string, str):
@@ -383,8 +383,9 @@ class Context(dict):
             x.
 
         Raises:
-            KeyError: input_string is not a sic string and has {somekey} where
-                      somekey does not exist in context dictionary.
+            KeyNotInContextError: input_string is not a sic string and has
+                                  {somekey} where somekey does not exist in
+                                  context dictionary.
         """
         if input_string[: 6] == '[sic]"':
             return input_string[6: -1]

--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -409,8 +409,6 @@ class Context(dict):
         if input_string[: 6] == '[sic]"':
             return input_string[6: -1]
         else:
-            print(f"doing input: {input_string}")
-
             # is this a special one field formatstring? i.e "{field}", with
             # nothing else?
             out = None
@@ -428,7 +426,6 @@ class Context(dict):
                     # second flag necessary because a literal with no format
                     # expression will still result in expr_count == 1
                     is_out_set = True
-                    print(f"just set out: {out}")
 
                 expr_count += 1
 
@@ -439,7 +436,6 @@ class Context(dict):
                 if expr_count > 1:
                     break
 
-            print(f"expression count: {expr_count}")
             if is_out_set and expr_count == 1:
                 # found 1 and only 1. but this could be an iterable obj
                 # that needs formatting rules run on it in itself

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -98,12 +98,14 @@ class Step(object):
                      mutate.
         """
         logger.debug("starting")
-        foreach_length = len(self.foreach_items)
-        logger.info(f"foreach decorator will loop {foreach_length} times.")
 
         # Loop decorators only evaluated once, not for every step repeat
         # execution.
         foreach = context.get_formatted_iterable(self.foreach_items)
+
+        foreach_length = len(foreach)
+
+        logger.info(f"foreach decorator will loop {foreach_length} times.")
 
         for i in foreach:
             logger.info(f"foreach: running step {i}")

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -21,7 +21,7 @@ class Step(object):
     Attributes:
         name: (string) this is the step-name. equivalent to the module name of
               of the step. this module is the one dynamically loaded to
-              step_module.
+              the module attribute.
         module: (importlib module) the dynamically loaded module that the
                 step will execute. this module will have the run_step
                 function that implements the actual step execution.
@@ -41,7 +41,7 @@ class Step(object):
 
         Args:
             step: a string or a dict. This is the actual step as it exists in
-                  the pipeline yaml - which is to say it can jsut be a string
+                  the pipeline yaml - which is to say it can just be a string
                   for a simple step, or a dict for a complex step.
         """
         logger.debug("starting")

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -1,0 +1,168 @@
+"""pypyr pipeline yaml definition classes - domain specific language"""
+
+import logging
+import pypyr.moduleloader
+
+# use pypyr logger to ensure loglevel is set correctly
+logger = logging.getLogger(__name__)
+
+
+class Step(object):
+    """A step, as interpreted by the pypyr pipeline definition yaml.
+
+    Encapsulates useful functions for the execution of a step, and also
+    maintains state necessary to run a step. Given the need to maintain state,
+    this is in a class, rather than purely functional code.
+
+    Dynamically loads the module that the step points at, interprets the step
+    decorators that modify step execution, and runs the actual step with
+    appropriate error handling.
+
+    Attributes:
+        name: (string) this is the step-name. equivalent to the module name of
+              of the step. this module is the one dynamically loaded to
+              step_module.
+        module: (importlib module) the dynamically loaded module that the
+                step will execute. this module will have the run_step
+                function that implements the actual step execution.
+        in_parameters: (dict) defaults None. The in step decorator - i.e dict
+                       to add to context before step execution.
+        run_me: (bool) defaults True. step runs if this is true.
+        skip_me: (bool) defaults False. step does not run if this is true.
+        swallow_me: (bool) defaults False. swallow any errors during step run
+                    and continue processing if true.
+    """
+
+    def __init__(self, step):
+        """Initialize the class. No duh, huh?
+
+        You can happily expect the initializer to initialize all
+        member attributes.
+
+        Args:
+            step: a string or a dict. This is the actual step as it exists in
+                  the pipeline yaml - which is to say it can jsut be a string
+                  for a simple step, or a dict for a complex step.
+        """
+        logger.debug("starting")
+
+        # defaults for decorators
+        self.in_parameters = None
+        self.run_me = True
+        self.skip_me = False
+        self.swallow_me = False
+        self.name = None
+
+        if isinstance(step, dict):
+            self.name = step['name']
+            logger.debug(f"{self.name} is complex.")
+
+            self.in_parameters = step.get('in', None)
+
+            # run: optional value, true by default. Allow substitution.
+            self.run_me = step.get('run', True)
+
+            # skip: optional value, false by default. Allow substitution.
+            self.skip_me = step.get('skip', False)
+
+            # swallow: optional, defaults false. Allow substitution.
+            self.swallow_me = step.get('swallow', False)
+        else:
+            # of course, it might not be a string. in line with duck typing,
+            # beg forgiveness later. as long as it loads the module, happy
+            # days.
+            logger.debug(f"{step} is a simple string.")
+            self.name = step
+
+        self.module = pypyr.moduleloader.get_module(self.name)
+
+        logger.debug("done")
+
+    def invoke_step(self, context):
+        """Invoke 'run_step' in the dynamically loaded step module.
+
+        Don't invoke this from outside the Step class. Use run_step instead.
+        invoke_step just does the bare module step invocation, it does not
+        evaluate any of the decorator logic surrounding the step. So unless
+        you really know what you're doing, use run_step if you intend on
+        executing the step the same way pypyr does.
+
+        Args:
+            context: (pypyr.context.Context) The pypyr context. This arg will
+                     mutate.
+        """
+        logger.debug("starting")
+
+        try:
+            logger.debug(f"running step {self.module}")
+
+            self.module.run_step(context)
+
+            logger.debug(f"step {self.module} done")
+        except AttributeError:
+            logger.error(f"The step {self.name} doesn't have a "
+                         "run_step(context) function.")
+            raise
+
+    def run_step(self, context):
+        """Run a single pipeline step.
+
+        Args:
+            context: (pypyr.context.Context) The pypyr context. This arg will
+                     mutate."""
+        logger.debug("starting")
+        # First things first, add the in params to context before step
+        # execution.
+        self.set_step_input_context(context)
+
+        # The decorator attributes might contain formatting expressions that
+        # change whether they evaluate True or False, thus apply formatting at
+        # last possible instant.
+        run_me = context.get_formatted_as_type(self.run_me, out_type=bool)
+        skip_me = context.get_formatted_as_type(self.skip_me, out_type=bool)
+        swallow_me = context.get_formatted_as_type(self.swallow_me,
+                                                   out_type=bool)
+
+        if run_me:
+            if not skip_me:
+                try:
+                    self.invoke_step(context=context)
+                except Exception as ex_info:
+                    if swallow_me:
+                        logger.error(
+                            f"{self.name} Ignoring error because swallow "
+                            "is True for this step.\n"
+                            f"{type(ex_info).__name__}: {ex_info}")
+                    else:
+                        raise
+            else:
+                logger.info(
+                    f"{self.name} not running because skip is True.")
+        else:
+            logger.info(f"{self.name} not running because run is False.")
+
+        logger.debug("done")
+
+    def set_step_input_context(self, context):
+        """Append step's 'in' parameters to context, if they exist.
+
+        Append the[in] dictionary to the context. This will overwrite
+        existing values if the same keys are already in there. I.e if
+        in_parameters has {'eggs': 'boiled'} and key 'eggs' already
+        exists in context, context['eggs'] hereafter will be 'boiled'.
+
+        Args:
+            context: (pypyr.context.Context) The pypyr context. This arg will
+                     mutate - after method execution will contain the new
+                     updated context.
+        """
+        logger.debug("starting")
+        if self.in_parameters is not None:
+            parameter_count = len(self.in_parameters)
+            if parameter_count > 0:
+                logger.debug(
+                    f"Updating context with {parameter_count} 'in' "
+                    "parameters.")
+                context.update(self.in_parameters)
+
+        logger.debug("done")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.10.0'
+__version__ = '0.11.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.11.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -106,7 +106,6 @@ def test_pipeline_name_required():
         with pytest.raises(SystemExit) as exit_err:
             pypyr.cli.main(arg_list)
 
-        print(exit_err.value)
         assert exit_err.value.code == 2
 
 

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -444,8 +444,8 @@ def test_tag_not_in_context_should_throw():
 
     assert repr(err.value) == (
         "KeyNotInContextError(\"Unable to format '{key1} this is "
-        "{key2} string' at context['input_string'] with {key2}, because "
-        "context['key2'] doesn't exist\",)")
+        "{key2} string' at context['input_string'], because "
+        "key2 not found in the pypyr context.\",)")
 
 
 def test_context_item_not_a_string_should_return_as_is():
@@ -477,9 +477,8 @@ def test_input_string_tag_not_in_context_should_throw():
         context.get_formatted_string(input_string)
 
     assert repr(err_info.value) == (
-        "KeyNotInContextError(\"Unable to format '{key1} this is "
-        "{key2} string' with {key2}, because context['key2'] doesn't "
-        "exist\",)")
+        "KeyNotInContextError(\"Unable to format '{key1} this is {key2} "
+        "string' because key2 not found in the pypyr context.\",)")
 
 
 def test_input_string_interpolate_sic():

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -1067,6 +1067,56 @@ def test_get_processed_string_sic_skips_interpolation():
     assert output == 'Piping {key1} the {key2} wild', (
         "string interpolation incorrect")
 
+
+def test_get_processed_string_single_expression_keeps_type():
+    context = Context(
+        {'ctx1': 'ctxvalue1',
+         'ctx2': 'ctxvalue2',
+         'ctx3': [0, 1, 3],
+         'ctx4': 'ctxvalue4'})
+
+    input_string = '{ctx3}'
+
+    output = context.get_processed_string(input_string)
+
+    assert output == [0, 1, 3]
+    assert isinstance(output, list)
+
+
+def test_get_processed_string_single_expression_keeps_type_and_iterates():
+    context = Context(
+        {'ctx1': 'ctxvalue1',
+         'ctx2': 'ctxvalue2',
+         'ctx3': [0,
+                  {'s1': 'v1',
+                   '{ctx1}': '{ctx2}',
+                   's3': [0, '{ctx4}']}, 3],
+         'ctx4': 'ctxvalue4'})
+
+    input_string = '{ctx3}'
+
+    output = context.get_processed_string(input_string)
+
+    assert output == [0,
+                      {'s1': 'v1',
+                       'ctxvalue1': 'ctxvalue2',
+                       's3': [0, 'ctxvalue4']}, 3]
+
+
+def test_get_processed_string_leading_literal():
+    context = Context({'k': 'down', 'key2': 'valleys', 'key3': 'value3'})
+    input_string = 'leading literal{k}'
+    output = context.get_processed_string(input_string)
+    assert output == 'leading literaldown', (
+        "string interpolation incorrect")
+
+
+def test_get_processed_string_following_literal():
+    context = Context({'k': 'down', 'key2': 'valleys', 'key3': 'value3'})
+    input_string = '{k}following literal'
+    output = context.get_processed_string(input_string)
+    assert output == 'downfollowing literal', (
+        "string interpolation incorrect")
 # ------------------- formats ------------------------------------------------#
 
 # ------------------- key info -----------------------------------------------#

--- a/tests/unit/pypyr/dsl_test.py
+++ b/tests/unit/pypyr/dsl_test.py
@@ -1,0 +1,1113 @@
+"""dsl.py unit tests."""
+import logging
+import pytest
+from unittest.mock import patch
+from pypyr.context import Context
+from pypyr.dsl import Step
+
+# ------------------- test context -------------------------------------------#
+
+
+def get_test_context():
+    """Return a pypyr context for testing."""
+    return Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'key4': [
+            {'k4lk1': 'value4',
+             'k4lk2': 'value5'},
+            {'k4lk1': 'value6',
+             'k4lk2': 'value7'}
+        ],
+        'key5': False,
+        'key6': True,
+        'key7': 77
+    })
+
+# ------------------- test context -------------------------------------------#
+
+# ------------------- step mocks ---------------------------------------------#
+
+
+def mock_run_step(context):
+    """Arbitrary mock function to execute instead of run_step"""
+    context['test_run_step'] = 'this was set in step'
+
+
+def mock_run_step_empty_context(context):
+    """Clear the context in the step."""
+    context.clear()
+
+
+def mock_run_step_none_context(context):
+    """None the context in the step"""
+    # ignore the context is not used flake8 warning
+    context = None  # noqa: F841
+# ------------------- step mocks ---------------------------------------------#
+
+# ------------------- Step----------------------------------------------------#
+# ------------------- Step: init ---------------------------------------------#
+
+
+@patch('pypyr.moduleloader.get_module', return_value='iamamodule')
+def test_simple_step_init_defaults(mocked_moduleloader):
+    """Simple step initializes with defaults as expected."""
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step = Step('blah')
+
+    mock_logger_debug.assert_any_call("blah is a simple string.")
+
+    assert step.name == 'blah'
+    assert step.module == 'iamamodule'
+    assert step.in_parameters is None
+    assert step.run_me
+    assert not step.skip_me
+    assert not step.swallow_me
+
+    mocked_moduleloader.assert_called_once_with('blah')
+
+
+@patch('pypyr.moduleloader.get_module', return_value='iamamodule')
+def test_complex_step_init_defaults(mocked_moduleloader):
+    """Complex step initializes with defaults as expected."""
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step = Step({'name': 'blah'})
+
+    mock_logger_debug.assert_any_call("blah is complex.")
+
+    assert step.name == 'blah'
+    assert step.module == 'iamamodule'
+    assert step.in_parameters is None
+    assert step.run_me
+    assert not step.skip_me
+    assert not step.swallow_me
+
+    mocked_moduleloader.assert_called_once_with('blah')
+
+
+@patch('pypyr.moduleloader.get_module', return_value='iamamodule')
+def test_complex_step_init_with_decorators(mocked_moduleloader):
+    """Complex step initializes with decorators set."""
+    step = Step({'name': 'blah',
+                 'in': {'k1': 'v1', 'k2': 'v2'},
+                 'run': False,
+                 'skip': True,
+                 'swallow': True,
+                 })
+    assert step.name == 'blah'
+    assert step.module == 'iamamodule'
+    assert step.in_parameters == {'k1': 'v1', 'k2': 'v2'}
+    assert not step.run_me
+    assert step.skip_me
+    assert step.swallow_me
+
+    mocked_moduleloader.assert_called_once_with('blah')
+
+# ------------------- Step: init ---------------------------------------------#
+
+# ------------------- Step: invoke_step---------------------------------------#
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_invoke_step_pass(mocked_moduleloader):
+    """run_pipeline_step test pass."""
+    step = Step('mocked.step')
+    step.invoke_step(get_test_context())
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    mocked_moduleloader.return_value.run_step.assert_called_once_with(
+        {'key1': 'value1',
+         'key2': 'value2',
+         'key3': 'value3',
+         'key4': [
+             {'k4lk1': 'value4', 'k4lk2': 'value5'},
+             {'k4lk1': 'value6', 'k4lk2': 'value7'}],
+         'key5': False,
+         'key6': True,
+         'key7': 77})
+
+
+@patch('pypyr.moduleloader.get_module', return_value=3)
+def test_invoke_step_no_run_step(mocked_moduleloader):
+    """run_pipeline_step fails if no run_step on imported module."""
+    step = Step('mocked.step')
+
+    with pytest.raises(AttributeError) as err_info:
+        step.invoke_step(get_test_context())
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+
+    assert repr(err_info.value) == (
+        "AttributeError(\"'int' object has no attribute 'run_step'\",)")
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_invoke_step_context_abides(mocked_moduleloader):
+    """Step mutates context & mutation abides after run_pipeline_step."""
+    mocked_moduleloader.return_value.run_step = mock_run_step
+    context = get_test_context()
+
+    step = Step('mocked.step')
+    step.invoke_step(context)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    assert context['test_run_step'] == 'this was set in step'
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_invoke_step_empty_context(mocked_moduleloader):
+    """Empty context in step (i.e count == 0, but not is None)"""
+    mocked_moduleloader.return_value.run_step = mock_run_step_empty_context
+    context = get_test_context()
+
+    step = Step('mocked.step')
+    step.invoke_step(context)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    assert len(context) == 0
+    assert context is not None
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_invoke_step_none_context(mocked_moduleloader):
+    """Step rebinding context to None doesn't affect the caller Context."""
+    mocked_moduleloader.return_value.run_step = mock_run_step_none_context
+    context = get_test_context()
+
+    step = Step('mocked.step')
+    step.invoke_step(False)
+
+    mocked_moduleloader.assert_called_once_with('mocked.step')
+    assert context == {'key1': 'value1',
+                       'key2': 'value2',
+                       'key3': 'value3',
+                       'key4': [
+                           {'k4lk1': 'value4', 'k4lk2': 'value5'},
+                           {'k4lk1': 'value6', 'k4lk2': 'value7'}],
+                       'key5': False,
+                       'key6': True,
+                       'key7': 77}
+
+# ------------------- Step: invoke_step---------------------------------------#
+
+# ------------------- Step: run_step: run ------------------------------------#
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_true(mock_invoke_step,
+                                                  mock_get_module):
+    """Complex step with run decorator set true will run step."""
+    step = Step({'name': 'step1',
+                 'run': True})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    step.run_step(context)
+
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_false(mock_invoke_step,
+                                                   mock_get_module):
+    """Complex step with run decorator set false doesn't run step."""
+    step = Step({'name': 'step1',
+                 'run': False})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call("step1 not running because run is False.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_str_formatting_false(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with run formatting expression false doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # name will evaluate False because it's a string and it's not 'True'.
+        'run': '{key1}'})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call("step1 not running because run is False.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_str_false(mock_invoke_step,
+                                                       mock_get_module):
+    """Complex step with run set to string False doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # name will evaluate False because it's a string and it's not 'True'.
+        'run': 'False'})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because run is False.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_str_lower_false(mock_invoke_step,
+                                                             mock_get_module):
+    """Complex step with run set to string false doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # name will evaluate False because it's a string and it's not 'True'.
+        'run': 'false'})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because run is False.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_bool_formatting_false(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with run formatting expression false doesn't run step."""
+    step = Step({
+        'name': 'step1',
+                # key5 will evaluate False because it's a bool and it's False
+                'run': '{key5}'})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because run is False.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_bool_formatting_true(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with run formatting expression true runs step."""
+    step = Step({
+        'name': 'step1',
+        # key6 will evaluate True because it's a bool and it's True
+        'run': '{key6}'})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_string_true(mock_invoke_step,
+                                                         mock_get_module):
+    """Complex step with run formatting expression True runs step."""
+    step = Step({
+        'name': 'step1',
+        # 'True' will evaluate bool True
+        'run': 'True'})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_1_true(mock_invoke_step,
+                                                    mock_get_module):
+    """Complex step with run 1 runs step."""
+    step = Step({
+        'name': 'step1',
+        # 1 will evaluate True because it's an int and 1
+        'run': 1})
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_99_true(mock_invoke_step,
+                                                     mock_get_module):
+    """Complex step with run 99 runs step."""
+    step = Step({
+        'name': 'step1',
+        # 99 will evaluate True because it's an int and > 0
+        'run': 99
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_neg1_true(mock_invoke_step,
+                                                       mock_get_module):
+    """Complex step with run -1 runs step."""
+    step = Step({
+        'name': 'step1',
+        # -1 will evaluate True because it's an int and != 0
+        'run': -1
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+# ------------------- Step: run_step: run ------------------------------------#
+
+
+# ------------------- Step: run_step: skip -----------------------------------#
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_false(mock_invoke_step,
+                                                    mock_get_module):
+    """Complex step with skip decorator set false will run step."""
+    step = Step({
+        'name': 'step1',
+        'skip': False
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_true(mock_invoke_step,
+                                                   mock_get_module):
+    """Complex step with skip decorator set true runa step."""
+    step = Step({
+        'name': 'step1',
+        'skip': True
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_str_formatting_false(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with skip formatting expression false doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # name will evaluate True
+        'skip': '{key6}'
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_str_true(mock_invoke_step,
+                                                       mock_get_module):
+    """Complex step with skip set to string False doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # skip evaluates True because it's a string and TRUE parses to True.
+        'skip': 'TRUE'
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_str_lower_true(mock_invoke_step,
+                                                             mock_get_module):
+    """Complex step with run set to string true doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # skip will evaluate true because it's a string and true is True.
+        'skip': 'true'
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_run_and_skip_bool_formatting_false(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with run doesn't run step, evals before skip."""
+    step = Step({
+        'name': 'step1',
+        # key5 will evaluate False because it's a bool and it's False
+        'run': '{key5}',
+        'skip': True
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because run is False.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_bool_formatting_false(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with skip formatting expression true runs step."""
+    step = Step({
+        'name': 'step1',
+        # key5 will evaluate False because it's a bool and it's False
+        'skip': '{key5}'
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_string_false(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with skip formatting expression False runs step."""
+    step = Step({
+        'name': 'step1',
+        # 'False' will evaluate bool False
+        'skip': 'False'
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_0_true(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with run 1 runs step."""
+    step = Step({
+        'name': 'step1',
+        # 0 will evaluate False because it's an int and 0
+        'skip': 0
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_99_true(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with skip 99 doesn't run step."""
+    step = Step({
+        'name': 'step1',
+        # 99 will evaluate True because it's an int and > 0
+        'skip': 99
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call(
+        "step1 not running because skip is True.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_skip_neg1_true(mock_invoke_step,
+                                                        mock_get_module):
+    """Complex step with run -1 runs step."""
+    step = Step({
+        'name': 'step1',
+        # -1 will evaluate True because it's an int and != 0
+        'skip': -1
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'info') as mock_logger_info:
+        step.run_step(context)
+
+    mock_logger_info.assert_any_call("step1 not running because skip is True.")
+    mock_invoke_step.assert_not_called()
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+# ------------------- Step: run_step: skip -----------------------------------#
+
+# ------------------- Step: run_step: swallow --------------------------------#
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_swallow_true(mock_invoke_step,
+                                                 mock_get_module):
+    """Complex step with swallow true runs normally even without error."""
+    step = Step({
+        'name': 'step1',
+        'swallow': True
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_swallow_false(mock_invoke_step,
+                                                  mock_get_module):
+    """Complex step with swallow false runs normally even without error."""
+    step = Step({
+        'name': 'step1',
+        'swallow': False
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step', side_effect=ValueError('arb error here'))
+def test_run_pipeline_steps_complex_swallow_true_error(mock_invoke_step,
+                                                       mock_get_module):
+    """Complex step with swallow true swallows error."""
+    step = Step({
+        'name': 'step1',
+        'swallow': 1
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        with patch.object(logger, 'error') as mock_logger_error:
+            step.run_step(context)
+
+    mock_logger_debug.assert_any_call("done")
+    mock_logger_error.assert_called_once_with(
+        "step1 Ignoring error because swallow is True "
+        "for this step.\n"
+        "ValueError: arb error here")
+    mock_invoke_step.assert_called_once_with(
+        context={'key1': 'value1',
+                 'key2': 'value2',
+                 'key3': 'value3',
+                 'key4': [
+                     {'k4lk1': 'value4',
+                      'k4lk2': 'value5'},
+                     {'k4lk1': 'value6',
+                      'k4lk2': 'value7'}
+                 ],
+                 'key5': False,
+                 'key6': True,
+                 'key7': 77})
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step', side_effect=ValueError('arb error here'))
+def test_run_pipeline_steps_complex_swallow_false_error(mock_invoke_step,
+                                                        mock_get_module):
+    """Complex step with swallow false raises error."""
+    step = Step({
+        'name': 'step1',
+        'swallow': 0
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    with pytest.raises(ValueError) as err_info:
+        step.run_step(context)
+
+        assert repr(err_info.value) == ("ValueError(\'arb error here',)")
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step', side_effect=ValueError('arb error here'))
+def test_run_pipeline_steps_complex_swallow_defaults_false_error(
+        mock_invoke_step,
+        mock_get_module):
+    """Complex step with swallow not specified still raises error."""
+    step = Step({
+        'name': 'step1'
+    })
+
+    context = get_test_context()
+    original_len = len(context)
+
+    with pytest.raises(ValueError) as err_info:
+        step.run_step(context)
+
+        assert repr(err_info.value) == ("ValueError(\'arb error here',)")
+
+    # validate all the in params ended up in context as intended
+    assert len(context) == original_len
+
+
+@patch('pypyr.moduleloader.get_module')
+@patch.object(Step, 'invoke_step', side_effect=ValueError('arb error here'))
+def test_run_pipeline_steps_simple_with_error(mock_invoke_step,
+                                              mock_get_module):
+    """Simple step run with error should not swallow."""
+    logger = logging.getLogger('pypyr.dsl')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        step = Step('step1')
+        with pytest.raises(ValueError) as err_info:
+            step.run_step(Context({'k1': 'v1'}))
+
+            assert repr(err_info.value) == (
+                "ValueError(\'arb error here',)")
+
+    mock_logger_debug.assert_any_call('step1 is a simple string.')
+    mock_invoke_step.assert_called_once_with(
+        context={'k1': 'v1'})
+
+# ------------------- Step: run_step: swallow --------------------------------#
+
+# ------------------- Step: set_step_input_context ---------------------------#
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_set_step_input_context_no_in_simple(mocked_moduleloader):
+    """Set step context does nothing if no in key found in simple step."""
+    step = Step('blah')
+    context = get_test_context()
+    step.set_step_input_context(context)
+
+    assert context == get_test_context()
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_set_step_input_context_no_in_complex(mocked_moduleloader):
+    """Set step context does nothing if no in key found in complex step."""
+    step = Step({'name': 'blah'})
+    context = get_test_context()
+    step.set_step_input_context(context)
+
+    assert context == get_test_context()
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_set_step_input_context_in_empty(mocked_moduleloader):
+    """Set step context does nothing if in key found but it's empty."""
+    step = Step({'name': 'blah', 'in': {}})
+    context = get_test_context()
+    step.set_step_input_context(context)
+
+    assert context == get_test_context()
+
+
+@patch('pypyr.moduleloader.get_module')
+def test_set_step_input_context_with_in(mocked_moduleloader):
+    """Set step context adds in to context."""
+    context = get_test_context()
+    original_len = len(context)
+    in_args = {'newkey1': 'v1',
+               'newkey2': 'v2',
+               'key3': 'updated in',
+               'key4': [0, 1, 2, 3],
+               'key5': True,
+               'key6': False,
+               'key7': 88}
+    step = Step({'name': 'blah', 'in': in_args})
+    step.set_step_input_context(context)
+
+    assert len(context) - 2 == original_len
+    assert context['newkey1'] == 'v1'
+    assert context['newkey2'] == 'v2'
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'value2'
+    assert context['key3'] == 'updated in'
+    assert context['key4'] == [0, 1, 2, 3]
+    assert context['key5']
+    assert not context['key6']
+    assert context['key7'] == 88
+
+# ------------------- Step: set_step_input_context ---------------------------#
+# ------------------- Step----------------------------------------------------#

--- a/tests/unit/pypyr/parser/list_test.py
+++ b/tests/unit/pypyr/parser/list_test.py
@@ -24,7 +24,6 @@ def test_empty_string_throw():
     with pytest.raises(AssertionError) as err_info:
         pypyr.parser.list.get_parsed_context(None)
 
-    print(repr(err_info.value))
     assert repr(err_info.value) == (
         "AssertionError(\"pipeline must be invoked with context arg set. For "
         "this list parser you're looking for something like: "

--- a/tests/unit/pypyr/steps/assert_test.py
+++ b/tests/unit/pypyr/steps/assert_test.py
@@ -271,7 +271,7 @@ def test_assert_passes_on_assertthis_equals_ints_substitutions():
 
 
 def test_assert_raises_on_assertthis_not_equals_ints_substitutions():
-    """assertThis string does not equal assertEquals bool."""
+    """assertThis string does not equal assertEquals int."""
     context = Context({'k1': 33,
                        'k2': 34,
                        'assertThis': '{k1}',
@@ -280,17 +280,23 @@ def test_assert_raises_on_assertthis_not_equals_ints_substitutions():
         assert_step.run_step(context)
 
     assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type str and does "
-        "not equal context['assertEquals'] of type str.\",)")
+        "ContextError(\"assert context['assertThis'] is of type int and does "
+        "not equal context['assertEquals'] of type int.\",)")
 
 
 def test_assert_passes_on_assertthis_not_equals_bools_substitutions():
-    """Format expressions equivocates string True and bool True."""
+    """Format expressions doesn't equivocate string True and bool True."""
     context = Context({'k1': True,
                        'k2': 'True',
                        'assertThis': '{k1}',
                        'assertEquals': '{k2}'})
-    assert_step.run_step(context)
+
+    with pytest.raises(ContextError) as err_info:
+        assert_step.run_step(context)
+
+    assert repr(err_info.value) == (
+        "ContextError(\"assert context['assertThis'] is of type bool and does "
+        "not equal context['assertEquals'] of type str.\",)")
 
 
 def test_assert_passes_on_assertthis_not_equals_none_substitutions():

--- a/tests/unit/pypyr/steps/contextmerge_test.py
+++ b/tests/unit/pypyr/steps/contextmerge_test.py
@@ -167,7 +167,6 @@ def test_get_formatted_iterable_nested_with_formatting_merge():
     pypyr.steps.contextmerge.run_step(context)
 
     output = context['output']
-    print(context)
 
     # context values outside of merge key remain unmolested
     assert context['ctx1'] == 'ctxvalue1'

--- a/tests/unit/pypyr/steps/contextmerge_test.py
+++ b/tests/unit/pypyr/steps/contextmerge_test.py
@@ -63,11 +63,12 @@ def test_contextmerge_pass_different_types_with_log():
 
     mock_logger_info.assert_called_once_with('merged 3 context items.')
 
-    assert context['kint'] == '33'
+    assert context['kint'] == 33
     assert context['k1'] == 33
-    assert context['kfloat'] == '123.45'
+    assert context['kfloat'] == 123.45
     assert context['k2'] == 123.45
-    assert context['kbool'] == 'False'
+    assert not context['kbool']
+    assert isinstance(context['kbool'], bool)
     assert not context['k3']
 
 

--- a/tests/unit/pypyr/steps/contextsetf_test.py
+++ b/tests/unit/pypyr/steps/contextsetf_test.py
@@ -77,11 +77,12 @@ def test_contextsetf_pass_different_types():
 
     pypyr.steps.contextsetf.run_step(context)
 
-    assert context['kint'] == '33'
+    assert context['kint'] == 33
     assert context['k1'] == 33
-    assert context['kfloat'] == '123.45'
+    assert context['kfloat'] == 123.45
     assert context['k2'] == 123.45
-    assert context['kbool'] == 'False'
+    assert not context['kbool']
+    assert isinstance(context['kbool'], bool)
     assert not context['k3']
 
 

--- a/tests/unit/pypyr/steps/default_test.py
+++ b/tests/unit/pypyr/steps/default_test.py
@@ -63,11 +63,12 @@ def test_contextdefault_pass_different_types_with_log():
 
     mock_logger_info.assert_called_once_with('set 3 context item defaults.')
 
-    assert context['kint'] == '33'
+    assert context['kint'] == 33
     assert context['k1'] == 33
-    assert context['kfloat'] == '123.45'
+    assert context['kfloat'] == 123.45
     assert context['k2'] == 123.45
-    assert context['kbool'] == 'False'
+    assert not context['kbool']
+    assert isinstance(context['kbool'], bool)
     assert not context['k3']
 
 

--- a/tests/unit/pypyr/stepsrunner_test.py
+++ b/tests/unit/pypyr/stepsrunner_test.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 from unittest.mock import call, patch
 from pypyr.context import Context
+from pypyr.dsl import Step
 from pypyr.errors import ContextError
 import pypyr.stepsrunner
 
@@ -59,25 +60,6 @@ def get_valid_test_pipeline():
     }
 # ------------------------- test context--------------------------------------#
 
-# ------------------------- step mocks ---------------------------------------#
-
-
-def mock_run_step(context):
-    """Arbitrary mock function to execute instead of run_step"""
-    context['test_run_step'] = 'this was set in step'
-
-
-def mock_run_step_empty_context(context):
-    """Clear the context in the step."""
-    context.clear()
-
-
-def mock_run_step_none_context(context):
-    """None the context in the step"""
-    # ignore the context is not used flake8 warning
-    context = None  # noqa: F841
-# ------------------------- step mocks ---------------------------------------#
-
 # ------------------------- get_pipeline_steps -------------------------------#
 
 
@@ -123,51 +105,6 @@ def test_get_pipeline_steps_none():
         "sg4: sequence has no elements. So it won't do anything.")
 # ------------------------- get_pipeline_steps--------------------------------#
 
-# ------------------------- get_step_input_context----------------------------#
-
-
-def test_get_step_input_context_no_in():
-    """Get step context does nothing if no in key found."""
-    context = get_test_context()
-    pypyr.stepsrunner.get_step_input_context(None, context)
-
-    assert context == get_test_context()
-
-
-def test_get_step_input_context_in_empty():
-    """Get step context does nothing if in key found but it's empty."""
-    context = get_test_context()
-    pypyr.stepsrunner.get_step_input_context({}, context)
-
-    assert context == get_test_context()
-
-
-def test_get_step_input_context_with_in():
-    """Get step context adds in to context."""
-    context = get_test_context()
-    original_len = len(context)
-    in_args = {'newkey1': 'v1',
-               'newkey2': 'v2',
-               'key3': 'updated in',
-               'key4': [0, 1, 2, 3],
-               'key5': True,
-               'key6': False,
-               'key7': 88}
-    pypyr.stepsrunner.get_step_input_context(in_args, context)
-
-    assert len(context) - 2 == original_len
-    assert context['newkey1'] == 'v1'
-    assert context['newkey2'] == 'v2'
-    assert context['key1'] == 'value1'
-    assert context['key2'] == 'value2'
-    assert context['key3'] == 'updated in'
-    assert context['key4'] == [0, 1, 2, 3]
-    assert context['key5']
-    assert not context['key6']
-    assert context['key7'] == 88
-
-# ------------------------- get_step_input_context----------------------------#
-
 # ------------------------- run_failure_step_group----------------------------#
 
 
@@ -200,85 +137,6 @@ def test_run_failure_step_group_swallows():
 
 # ------------------------- run_failure_step_group----------------------------#
 
-# ------------------------- run_pipeline_step---------------------------------#
-
-
-@patch('pypyr.moduleloader.get_module')
-def test_run_pipeline_step_pass(mocked_moduleloader):
-    """run_pipeline_step test pass."""
-    pypyr.stepsrunner.run_pipeline_step('mocked.step', get_test_context())
-
-    mocked_moduleloader.assert_called_once_with('mocked.step')
-    mocked_moduleloader.return_value.run_step.assert_called_once_with(
-        {'key1': 'value1',
-         'key2': 'value2',
-         'key3': 'value3',
-         'key4': [
-             {'k4lk1': 'value4', 'k4lk2': 'value5'},
-             {'k4lk1': 'value6', 'k4lk2': 'value7'}],
-         'key5': False,
-         'key6': True,
-         'key7': 77})
-
-
-@patch('pypyr.moduleloader.get_module', return_value=3)
-def test_run_pipeline_step_no_run_step(mocked_moduleloader):
-    """run_pipeline_step fails if no run_step on imported module."""
-    with pytest.raises(AttributeError) as err_info:
-        pypyr.stepsrunner.run_pipeline_step('mocked.step', get_test_context)
-
-    mocked_moduleloader.assert_called_once_with('mocked.step')
-
-    assert repr(err_info.value) == (
-        "AttributeError(\"'int' object has no attribute 'run_step'\",)")
-
-
-@patch('pypyr.moduleloader.get_module')
-def test_run_pipeline_step_context_abides(mocked_moduleloader):
-    """Steps mutate context & mutation abides after run_pipeline_step."""
-    mocked_moduleloader.return_value.run_step = mock_run_step
-    context = get_test_context()
-
-    pypyr.stepsrunner.run_pipeline_step('mocked.step', context)
-
-    mocked_moduleloader.assert_called_once_with('mocked.step')
-    assert context['test_run_step'] == 'this was set in step'
-
-
-@patch('pypyr.moduleloader.get_module')
-def test_run_pipeline_step_empty_context(mocked_moduleloader):
-    """Empty context in step (i.e count == 0, but not is None)"""
-    mocked_moduleloader.return_value.run_step = mock_run_step_empty_context
-    context = get_test_context()
-
-    pypyr.stepsrunner.run_pipeline_step('mocked.step', context)
-
-    mocked_moduleloader.assert_called_once_with('mocked.step')
-    assert len(context) == 0
-    assert context is not None
-
-
-@patch('pypyr.moduleloader.get_module')
-def test_run_pipeline_step_none_context(mocked_moduleloader):
-    """Step rebinding context to None doesn't affect the caller Context."""
-    mocked_moduleloader.return_value.run_step = mock_run_step_none_context
-    context = get_test_context()
-
-    pypyr.stepsrunner.run_pipeline_step('mocked.step', False)
-
-    mocked_moduleloader.assert_called_once_with('mocked.step')
-    assert context == {'key1': 'value1',
-                       'key2': 'value2',
-                       'key3': 'value3',
-                       'key4': [
-                           {'k4lk1': 'value4', 'k4lk2': 'value5'},
-                           {'k4lk1': 'value6', 'k4lk2': 'value7'}],
-                       'key5': False,
-                       'key6': True,
-                       'key7': 77}
-
-# ------------------------- run_pipeline_step---------------------------------#
-
 # ------------------------- run_pipeline_steps--------------------------------#
 
 
@@ -291,21 +149,22 @@ def test_run_pipeline_steps_none():
     mock_logger_debug.assert_any_call("No steps found to execute.")
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex(mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex(mock_invoke_step, mock_module):
     """Complex step run with no in args."""
-    logger = logging.getLogger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.dsl')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(
             [{'name': 'step1'}], Context({'k1': 'v1'}))
 
     mock_logger_debug.assert_any_call("step1 is complex.")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'k1': 'v1'})
+    mock_invoke_step.assert_called_once_with(context={'k1': 'v1'})
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_in(mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_in(mock_invoke_step, mock_module):
     """Complex step run with in args. In args added to context for run_step."""
     steps = [{
         'name': 'step1',
@@ -325,363 +184,25 @@ def test_run_pipeline_steps_complex_with_in(mock_run_step):
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
     mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'updated in',
-                                    'key4': [0, 1, 2, 3],
-                                    'key5': True,
-                                    'key6': False,
-                                    'key7': 88,
-                                    'newkey1': 'v1',
-                                    'newkey2': 'v2'})
+    mock_invoke_step.assert_called_once_with(context={'key1': 'value1',
+                                                      'key2': 'value2',
+                                                      'key3': 'updated in',
+                                                      'key4': [0, 1, 2, 3],
+                                                      'key5': True,
+                                                      'key6': False,
+                                                      'key7': 88,
+                                                      'newkey1': 'v1',
+                                                      'newkey2': 'v2'})
 
     # validate all the in params ended up in context as intended
     assert len(context) - 2 == original_len
 
-# -----------------------  run_pipeline_steps: run -----------------------#
+# -----------------------  run_pipeline_steps: run ---------------------------#
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_true(mock_run_step):
-    """Complex step with run decorator set true will run step."""
-    steps = [{
-        'name': 'step1',
-        'run': True
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_false(mock_run_step):
-    """Complex step with run decorator set false doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        'run': False
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because run is False.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_str_formatting_false(
-        mock_run_step):
-    """Complex step with run formatting expression false doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # name will evaluate False because it's a string and it's not 'True'.
-        'run': '{key1}'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because run is False.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_str_false(
-        mock_run_step):
-    """Complex step with run set to string False doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # name will evaluate False because it's a string and it's not 'True'.
-        'run': 'False'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because run is False.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_str_lower_false(
-        mock_run_step):
-    """Complex step with run set to string false doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # name will evaluate False because it's a string and it's not 'True'.
-        'run': 'false'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because run is False.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_bool_formatting_false(
-        mock_run_step):
-    """Complex step with run formatting expression false doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # key5 will evaluate False because it's a bool and it's False
-        'run': '{key5}'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because run is False.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_bool_formatting_true(
-        mock_run_step):
-    """Complex step with run formatting expression true runs step."""
-    steps = [{
-        'name': 'step1',
-        # key6 will evaluate True because it's a bool and it's True
-        'run': '{key6}'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_string_true(
-        mock_run_step):
-    """Complex step with run formatting expression True runs step."""
-    steps = [{
-        'name': 'step1',
-        # 'True' will evaluate bool True
-        'run': 'True'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_1_true(
-        mock_run_step):
-    """Complex step with run 1 runs step."""
-    steps = [{
-        'name': 'step1',
-        # 1 will evaluate True because it's an int and 1
-        'run': 1
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_99_true(
-        mock_run_step):
-    """Complex step with run 99 runs step."""
-    steps = [{
-        'name': 'step1',
-        # 99 will evaluate True because it's an int and > 0
-        'run': 99
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_neg1_true(
-        mock_run_step):
-    """Complex step with run -1 runs step."""
-    steps = [{
-        'name': 'step1',
-        # -1 will evaluate True because it's an int and != 0
-        'run': -1
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_mix_run_and_not_run(
-        mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_mix_run_and_not_run(mock_invoke_step, mock_module):
     """Complex steps, some run some don't."""
     # Step 1 & 3 runs, 2 should not.
     steps = [{
@@ -700,17 +221,18 @@ def test_run_pipeline_steps_mix_run_and_not_run(
     context = get_test_context()
     original_len = len(context)
 
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        with patch.object(logger, 'info') as mock_logger_info:
+    logger_steps = logging.getLogger('pypyr.stepsrunner')
+    logger_dsl = logging.getLogger('pypyr.dsl')
+    with patch.object(logger_steps, 'debug') as mock_logger_debug:
+        with patch.object(logger_dsl, 'info') as mock_logger_info:
             pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
     mock_logger_debug.assert_any_call("executed 3 steps")
     mock_logger_info.assert_any_call(
         "step2 not running because run is False.")
 
-    assert mock_run_step.call_count == 2
-    assert mock_run_step.mock_calls == [call(context={
+    assert mock_invoke_step.call_count == 2
+    assert mock_invoke_step.mock_calls == [call(context={
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3', 'key4':
@@ -724,8 +246,7 @@ def test_run_pipeline_steps_mix_run_and_not_run(
             }],
         'key5': False,
         'key6': True,
-        'key7': 77},
-        step_name='step1'),
+        'key7': 77}),
         call(context={
             'key1': 'value1',
             'key2': 'value2',
@@ -740,16 +261,16 @@ def test_run_pipeline_steps_mix_run_and_not_run(
                 }],
             'key5': False,
             'key6': True,
-            'key7': 77},
-            step_name='step3')]
+            'key7': 77})]
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_multistep_none_run(
-        mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_multistep_none_run(mock_invoke_step,
+                                                            mock_module):
     """Multiple steps and none run."""
     # None of these should run - various shades of python false
     steps = [{
@@ -769,7 +290,7 @@ def test_run_pipeline_steps_complex_with_multistep_none_run(
     context = get_test_context()
     original_len = len(context)
 
-    logger = logging.getLogger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.dsl')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -779,335 +300,19 @@ def test_run_pipeline_steps_complex_with_multistep_none_run(
         "step2 not running because run is False.")
     mock_logger_info.assert_any_call(
         "step3 not running because run is False.")
-    mock_run_step.assert_not_called()
+    mock_invoke_step.assert_not_called()
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
-
-# -----------------------  END run_pipeline_steps: run -----------------------#
+# -----------------------  run_pipeline_steps: run ---------------------------#
 
 # -----------------------  run_pipeline_steps: skip --------------------------#
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_false(mock_run_step):
-    """Complex step with skip decorator set false will run step."""
-    steps = [{
-        'name': 'step1',
-        'skip': False
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_true(mock_run_step):
-    """Complex step with skip decorator set true runa step."""
-    steps = [{
-        'name': 'step1',
-        'skip': True
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because skip is True.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_str_formatting_false(
-        mock_run_step):
-    """Complex step with skip formatting expression false doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # name will evaluate True
-        'skip': '{key6}'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because skip is True.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_str_true(
-        mock_run_step):
-    """Complex step with skip set to string False doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # skip evaluates True because it's a string and TRUE parses to True.
-        'skip': 'TRUE'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because skip is True.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_str_lower_true(
-        mock_run_step):
-    """Complex step with run set to string true doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # skip will evaluate true because it's a string and true is True.
-        'skip': 'true'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because skip is True.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_run_and_skip_bool_formatting_false(
-        mock_run_step):
-    """Complex step with run doesn't run step, evals before skip."""
-    steps = [{
-        'name': 'step1',
-        # key5 will evaluate False because it's a bool and it's False
-        'run': '{key5}',
-        'skip': True
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because run is False.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_bool_formatting_false(
-        mock_run_step):
-    """Complex step with skip formatting expression true runs step."""
-    steps = [{
-        'name': 'step1',
-        # key5 will evaluate False because it's a bool and it's False
-        'skip': '{key5}'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_string_false(
-        mock_run_step):
-    """Complex step with skip formatting expression False runs step."""
-    steps = [{
-        'name': 'step1',
-        # 'False' will evaluate bool False
-        'skip': 'False'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_0_true(
-        mock_run_step):
-    """Complex step with run 1 runs step."""
-    steps = [{
-        'name': 'step1',
-        # 0 will evaluate False because it's an int and 0
-        'skip': 0
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_99_true(
-        mock_run_step):
-    """Complex step with skip 99 doesn't run step."""
-    steps = [{
-        'name': 'step1',
-        # 99 will evaluate True because it's an int and > 0
-        'skip': 99
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because skip is True.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_skip_neg1_true(
-        mock_run_step):
-    """Complex step with run -1 runs step."""
-    steps = [{
-        'name': 'step1',
-        # -1 will evaluate True because it's an int and != 0
-        'skip': -1
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'info') as mock_logger_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_info.assert_any_call(
-        "step1 not running because skip is True.")
-    mock_run_step.assert_not_called()
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_mix_skip_and_not_skip(
-        mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_mix_skip_and_not_skip(mock_invoke_step,
+                                                  mock_module):
     """Complex steps, some run some don't."""
     # Step 1 & 3 runs, 2 should not.
     steps = [{
@@ -1126,17 +331,18 @@ def test_run_pipeline_steps_mix_skip_and_not_skip(
     context = get_test_context()
     original_len = len(context)
 
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        with patch.object(logger, 'info') as mock_logger_info:
+    logger_steps = logging.getLogger('pypyr.stepsrunner')
+    logger_dsl = logging.getLogger('pypyr.dsl')
+    with patch.object(logger_steps, 'debug') as mock_logger_debug:
+        with patch.object(logger_dsl, 'info') as mock_logger_info:
             pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
     mock_logger_debug.assert_any_call("executed 3 steps")
     mock_logger_info.assert_any_call(
         "step2 not running because skip is True.")
 
-    assert mock_run_step.call_count == 2
-    assert mock_run_step.mock_calls == [call(context={
+    assert mock_invoke_step.call_count == 2
+    assert mock_invoke_step.mock_calls == [call(context={
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3', 'key4':
@@ -1150,8 +356,7 @@ def test_run_pipeline_steps_mix_skip_and_not_skip(
             }],
         'key5': False,
         'key6': True,
-        'key7': 77},
-        step_name='step1'),
+        'key7': 77}),
         call(context={
             'key1': 'value1',
             'key2': 'value2',
@@ -1166,16 +371,16 @@ def test_run_pipeline_steps_mix_skip_and_not_skip(
                 }],
             'key5': False,
             'key6': True,
-            'key7': 77},
-            step_name='step3')]
+            'key7': 77})]
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_with_multistep_all_skip(
-        mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_complex_with_multistep_all_skip(mock_invoke_step,
+                                                            mock_module):
     """Multiple steps and none run."""
     # None of these should run - various shades of python true
     steps = [{
@@ -1201,7 +406,7 @@ def test_run_pipeline_steps_complex_with_multistep_all_skip(
     context = get_test_context()
     original_len = len(context)
 
-    logger = logging.getLogger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.dsl')
     with patch.object(logger, 'info') as mock_logger_info:
         pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
@@ -1213,173 +418,19 @@ def test_run_pipeline_steps_complex_with_multistep_all_skip(
         "step3 not running because skip is True.")
     mock_logger_info.assert_any_call(
         "step4 not running because run is False.")
-    mock_run_step.assert_not_called()
+    mock_invoke_step.assert_not_called()
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
 
 # -----------------------  END run_pipeline_steps: skip ----------------------#
 
-# -----------------------  END run_pipeline_steps: swallow--------------------#
+# -----------------------  run_pipeline_steps: swallow -----------------------#
 
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_swallow_true(
-        mock_run_step):
-    """Complex step with swallow true runs normally even without error."""
-    steps = [{
-        'name': 'step1',
-        'swallow': True
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_complex_swallow_false(
-        mock_run_step):
-    """Complex step with swallow false runs normally even without error."""
-    steps = [{
-        'name': 'step1',
-        'swallow': False
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step',
-       side_effect=ValueError('arb error here'))
-def test_run_pipeline_steps_complex_swallow_true_error(
-        mock_run_step):
-    """Complex step with swallow true swallows error."""
-    steps = [{
-        'name': 'step1',
-        'swallow': 1
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        with patch.object(logger, 'error') as mock_logger_error:
-            pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-    mock_logger_debug.assert_any_call("executed 1 steps")
-    mock_logger_error.assert_called_once_with(
-        "step1 Ignoring error because swallow is True "
-        "for this step.\n"
-        "ValueError: arb error here")
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'key1': 'value1',
-                                    'key2': 'value2',
-                                    'key3': 'value3',
-                                    'key4': [
-                                        {'k4lk1': 'value4',
-                                         'k4lk2': 'value5'},
-                                        {'k4lk1': 'value6',
-                                         'k4lk2': 'value7'}
-                                    ],
-                                    'key5': False,
-                                    'key6': True,
-                                    'key7': 77})
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step',
-       side_effect=ValueError('arb error here'))
-def test_run_pipeline_steps_complex_swallow_false_error(
-        mock_run_step):
-    """Complex step with swallow false raises error."""
-    steps = [{
-        'name': 'step1',
-        'swallow': 0
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    with pytest.raises(ValueError) as err_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-        assert repr(err_info.value) == ("ValueError(\'arb error here',)")
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step',
-       side_effect=ValueError('arb error here'))
-def test_run_pipeline_steps_complex_swallow_defaults_false_error(
-        mock_run_step):
-    """Complex step with swallow not specified still raises error."""
-    steps = [{
-        'name': 'step1'
-    }]
-
-    context = get_test_context()
-    original_len = len(context)
-
-    with pytest.raises(ValueError) as err_info:
-        pypyr.stepsrunner.run_pipeline_steps(steps, context)
-
-        assert repr(err_info.value) == ("ValueError(\'arb error here',)")
-
-    # validate all the in params ended up in context as intended
-    assert len(context) == original_len
-
-
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_swallow_sequence(
-        mock_run_step):
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'invoke_step')
+def test_run_pipeline_steps_swallow_sequence(mock_invoke_step, mock_module):
     """Complex steps, some run some don't, some swallow, some don't."""
     # 1 & 2 don't run,
     # 3 runs, no error
@@ -1387,35 +438,36 @@ def test_run_pipeline_steps_swallow_sequence(
     # 5 skips
     # 6 runs, error and raises
     # 7 doesn't run because execution stopped at 6 because of error
-    mock_run_step.side_effect = [
+    mock_invoke_step.side_effect = [
         None,  # 3
         ValueError('arb error here 4'),  # 4
         ValueError('arb error here 6'),  # 6
     ]
 
-    steps = [{
-        'name': 'step1',
-        'run': False
-    },
+    steps = [
         {
-        'name': 'step2',
-        'skip': True
-    },
+            'name': 'step1',
+            'run': False
+        },
         {
-        'name': 'step3',
-    },
+            'name': 'step2',
+            'skip': True
+        },
         {
-        'name': 'step4',
-        'run': True,
-        'skip': False,
-        'swallow': 1
-    },
+            'name': 'step3',
+        },
         {
-        'name': 'step5',
-        'run': True,
-        'skip': True,
-        'swallow': True
-    },
+            'name': 'step4',
+            'run': True,
+            'skip': False,
+            'swallow': 1
+        },
+        {
+            'name': 'step5',
+            'run': True,
+            'skip': True,
+            'swallow': True
+        },
         'step6',
         'step7',
     ]
@@ -1423,7 +475,7 @@ def test_run_pipeline_steps_swallow_sequence(
     context = get_test_context()
     original_len = len(context)
 
-    logger = logging.getLogger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.dsl')
     with patch.object(logger, 'debug') as mock_logger_debug:
         with patch.object(logger, 'info') as mock_logger_info:
             with patch.object(logger, 'error') as mock_logger_error:
@@ -1433,13 +485,12 @@ def test_run_pipeline_steps_swallow_sequence(
                     assert repr(err_info.value) == (
                         "ValueError(\'arb error here 6',)")
 
-    assert mock_logger_debug.mock_calls == [call('starting'),
-                                            call('step1 is complex.'),
-                                            call('step2 is complex.'),
-                                            call('step3 is complex.'),
-                                            call('step4 is complex.'),
-                                            call('step5 is complex.'),
-                                            call('step6 is a simple string.')]
+    mock_logger_debug.assert_has_calls == [call('step1 is complex.'),
+                                           call('step2 is complex.'),
+                                           call('step3 is complex.'),
+                                           call('step4 is complex.'),
+                                           call('step5 is complex.'),
+                                           call('step6 is a simple string.')]
 
     mock_logger_info.mock_calls == [
         call('step1 not running because run is False.'),
@@ -1451,8 +502,8 @@ def test_run_pipeline_steps_swallow_sequence(
         "for this step.\n"
         "ValueError: arb error here 4")
 
-    assert mock_run_step.call_count == 3
-    assert mock_run_step.mock_calls == [call(context={
+    assert mock_invoke_step.call_count == 3
+    assert mock_invoke_step.mock_calls == [call(context={
         'key1': 'value1',
         'key2': 'value2',
         'key3': 'value3', 'key4':
@@ -1466,8 +517,7 @@ def test_run_pipeline_steps_swallow_sequence(
             }],
         'key5': False,
         'key6': True,
-        'key7': 77},
-        step_name='step3'),
+        'key7': 77}),
         call(context={
             'key1': 'value1',
             'key2': 'value2',
@@ -1482,8 +532,7 @@ def test_run_pipeline_steps_swallow_sequence(
                 }],
             'key5': False,
             'key6': True,
-            'key7': 77},
-            step_name='step4'),
+            'key7': 77}),
         call(context={
             'key1': 'value1',
             'key2': 'value2',
@@ -1498,42 +547,27 @@ def test_run_pipeline_steps_swallow_sequence(
                 }],
             'key5': False,
             'key6': True,
-            'key7': 77},
-            step_name='step6')]
+            'key7': 77})]
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
 
 # -----------------------  END run_pipeline_steps: swallow------------------#
 
+# ------------------------- run_pipeline_steps--------------------------------#
 
-@patch('pypyr.stepsrunner.run_pipeline_step')
-def test_run_pipeline_steps_simple(mock_run_step):
+
+@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch.object(Step, 'run_step')
+def test_run_pipeline_steps_simple(mock_run_step, mock_module):
     """Simple step run."""
-    logger = logging.getLogger('pypyr.stepsrunner')
+    logger = logging.getLogger('pypyr.dsl')
     with patch.object(logger, 'debug') as mock_logger_debug:
         pypyr.stepsrunner.run_pipeline_steps(['step1'], {'k1': 'v1'})
 
     mock_logger_debug.assert_any_call('step1 is a simple string.')
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'k1': 'v1'})
+    mock_run_step.assert_called_once_with({'k1': 'v1'})
 
-
-@patch('pypyr.stepsrunner.run_pipeline_step',
-       side_effect=ValueError('arb error here'))
-def test_run_pipeline_steps_simple_with_error(mock_run_step):
-    """Simple step run with error should not swallow."""
-    logger = logging.getLogger('pypyr.stepsrunner')
-    with patch.object(logger, 'debug') as mock_logger_debug:
-        with pytest.raises(ValueError) as err_info:
-            pypyr.stepsrunner.run_pipeline_steps(['step1'], {'k1': 'v1'})
-
-            assert repr(err_info.value) == (
-                "ValueError(\'arb error here',)")
-
-    mock_logger_debug.assert_any_call('step1 is a simple string.')
-    mock_run_step.assert_called_once_with(
-        step_name='step1', context={'k1': 'v1'})
 
 # ------------------------- run_pipeline_steps--------------------------------#
 


### PR DESCRIPTION
- *foreach* decorator
- big refactor of stepsrunner. the new module `pypyr.dsl` contains classes (for now, `Step`), that model the pypyr pipeline yaml Domain Specific Language. this made foreach easier.
- some cleanup on consistent error types - KeyNotInContextError rather than KeyError for all context key lookup errors.
- big refactor of format strings aka string interpolation. 
  - optimize: no more unnecessary dict unpacking and repacking by now using `format_map(context)` rather than `format(**context)` 
  - single format expression now functions akin to a dictionary path in xpath style. e.g a string formatting expression like `'{key1[0]}'` will fetch the first item in the list at `key` and keep the original type of that item *without converting it to string*. In this example, the format expression would return a list:
```
  key1:
       - ['list', 'here']
       - 1
```
- format expressions like `{key1} literal text {key2}` will obviously still return type strings
- version bump for new release