### PR TITLE
python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,12 +80,12 @@ pypyr assumes a pipelines directory in your current working directory.
 .. code-block:: bash
 
   # run pipelines/mypipelinename.yaml with DEBUG logging level
-  $ pypyr mypipelinename --log 10
+  $ pypyr mypipelinename --loglevel 10
 
   # run pipelines/mypipelinename.yaml with INFO logging level.
-  $ pypyr mypipelinename --log 20
+  $ pypyr mypipelinename --logl 20
 
-  # If you don't specify --log it defaults to 20 - INFO logging level.
+  # If you don't specify --loglevel it defaults to 20 - INFO logging level.
   $ pypyr mypipelinename
 
   # run pipelines/mypipelinename.yaml. The 2nd argument is any arbitrary string,

--- a/README.rst
+++ b/README.rst
@@ -1412,6 +1412,21 @@ Friendly reminder of the difference between separating your commands with ; or
   It won't exit with an error code if it wasn't the last statement.
 - && stops and exits reporting error on first error.
 
+You can change directory during this shell step using ``cd``, but dir changes
+are only in scope for subsequent commands in this step, not for subsequent
+steps:
+
+.. code-block:: yaml
+
+  - name: pypyr.steps.shell
+    description: hop one up from current working dir
+    in:
+      cmd: '[sic]"echo ${PWD}; cd ../; echo ${PWD}"'
+  - name: pypyr.steps.shell
+    description: back to your current working dir
+    in:
+      cmd: '[sic]"echo ${PWD}"'
+
 Supports string `Substitutions`_.
 
 Example pipeline yaml using a pipe:
@@ -1422,6 +1437,10 @@ Example pipeline yaml using a pipe:
     - name: pypyr.steps.shell
       in:
         cmd: ls | grep pipe; echo if you had something pipey it should show up;
+    - name: pypyr.steps.shell
+      description: if you want to pass curlies to the shell, use sic strings
+      in:
+        cmd: '[sic]"echo ${PWD};"'
 
 See a worked example `for shell power here
 <https://github.com/pypyr/pypyr-example/tree/master/pipelines/shell.yaml>`__.
@@ -1634,6 +1653,29 @@ Will return "piping {key} the valleys wild" without attempting to substitute
 {key} from context. You can happily use ", ' or {} inside a ``[sic]""`` string
 without escaping these any further. This makes sic strings ideal for strings
 containing json.
+
+In pipeline yaml, you need to have the ``[sic]`` in single quotes or as part
+of a literal block:
+
+.. code-block:: yaml
+
+  - name: pypyr.steps.echo
+    description: >
+                use a sic string not to format any {values}. Do watch the
+                use of the yaml literal with block chomping indicator |- to
+                prevent the last character in the string from being a LF. If
+                you don't do this, you will end up with the trailing " in your
+                output, which in this case would be malformed json.
+    in:
+      echoMe: |-
+              [sic]"
+              {
+                "key1": "key1 value with a {curly}"
+              }"
+  - name: pypyr.steps.echo
+    description: put sic string in single quotes
+    in:
+      echoMe: '[sic]"string with a {curly} with ", '' and & and double quote at end:""'
 
 See a worked example `for substitutions here
 <https://github.com/pypyr/pypyr-example/tree/master/pipelines/substitutions.yaml>`__.

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 
 [bdist_wheel]
 universal = 0

--- a/shippable.yaml
+++ b/shippable.yaml
@@ -3,6 +3,7 @@ language: python
 
 python:
  - "3.6"
+ - "3.7"
 
 build:
   ci:

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -146,10 +146,9 @@ def test_assert_key_has_value_fails_key_error_message():
     with pytest.raises(KeyNotInContextError) as err_info:
         context.assert_key_has_value('notindict', 'mydesc')
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['notindict'] "
-        "doesn't exist. It must exist for "
-        "mydesc.\",)")
+    assert str(err_info.value) == ("context['notindict'] "
+                                   "doesn't exist. It must exist for "
+                                   "mydesc.")
 
 
 def test_assert_key_has_value_fails_key_empty():
@@ -218,8 +217,7 @@ def test_assert_key_type_value_no_key_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         Context().assert_key_type_value(info, 'mydesc')
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"mydesc couldn't find key1 in context.\",)")
+    assert str(err_info.value) == "mydesc couldn't find key1 in context."
 
 
 def test_assert_key_type_value_no_key_raises_extra_text():
@@ -233,9 +231,8 @@ def test_assert_key_type_value_no_key_raises_extra_text():
     with pytest.raises(KeyNotInContextError) as err_info:
         Context().assert_key_type_value(info, 'mydesc', 'extra text here')
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"mydesc couldn't find key1 in context. extra "
-        "text here\",)")
+    assert str(err_info.value) == (
+        "mydesc couldn't find key1 in context. extra text here")
 
 
 def test_assert_key_type_value_no_value_raises():
@@ -249,9 +246,8 @@ def test_assert_key_type_value_no_value_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         Context().assert_key_type_value(info, 'mydesc')
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"mydesc found key1 in context but it "
-        "doesn\'t have a value.\",)")
+    assert str(err_info.value) == ("mydesc found key1 in context but it "
+                                   "doesn\'t have a value.")
 
 
 def test_assert_key_type_value_no_value_raises_extra_text():
@@ -265,9 +261,8 @@ def test_assert_key_type_value_no_value_raises_extra_text():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         Context().assert_key_type_value(info, 'mydesc', 'extra text here')
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"mydesc found key1 in context but it "
-        "doesn\'t have a value. extra text here\",)")
+    assert str(err_info.value) == ("mydesc found key1 in context but it "
+                                   "doesn\'t have a value. extra text here")
 
 
 def test_assert_key_type_value_wrong_type_raises():
@@ -281,9 +276,8 @@ def test_assert_key_type_value_wrong_type_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         Context().assert_key_type_value(info, 'mydesc')
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"mydesc found key1 in context, but "
-        "it\'s not a <class 'str'>.\",)")
+    assert str(err_info.value) == ("mydesc found key1 in context, but "
+                                   "it\'s not a <class 'str'>.")
 
 
 def test_assert_key_type_value_wrong_type_raises_with_extra_error_text():
@@ -297,9 +291,9 @@ def test_assert_key_type_value_wrong_type_raises_with_extra_error_text():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         Context().assert_key_type_value(info, 'mydesc', 'extra text here')
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"mydesc found key1 in context, but "
-        "it\'s not a <class 'str'>. extra text here\",)")
+    assert str(err_info.value) == (
+        "mydesc found key1 in context, but "
+        "it\'s not a <class 'str'>. extra text here")
 
 
 def test_assert_keys_type_value_passes():
@@ -348,9 +342,8 @@ def test_assert_keys_type_value_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         Context().assert_keys_type_value('mydesc', None, info1, info2, info3)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"mydesc found key2 in context but it "
-        "doesn\'t have a value.\",)")
+    assert str(err_info.value) == ("mydesc found key2 in context but it "
+                                   "doesn\'t have a value.")
 
 
 def test_assert_keys_type_value_raises_with_extra_error_text():
@@ -380,9 +373,8 @@ def test_assert_keys_type_value_raises_with_extra_error_text():
                                          info2,
                                          info3)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"mydesc found key2 in context but it "
-        "doesn\'t have a value. extra text here\",)")
+    assert str(err_info.value) == ("mydesc found key2 in context but it "
+                                   "doesn\'t have a value. extra text here")
 
 # ------------------- asserts ------------------------------------------------#
 
@@ -442,10 +434,10 @@ def test_tag_not_in_context_should_throw():
         context['input_string'] = '{key1} this is {key2} string'
         context.get_formatted('input_string')
 
-    assert repr(err.value) == (
-        "KeyNotInContextError(\"Unable to format '{key1} this is "
+    assert str(err.value) == (
+        "Unable to format '{key1} this is "
         "{key2} string' at context['input_string'], because "
-        "key2 not found in the pypyr context.\",)")
+        "key2 not found in the pypyr context.")
 
 
 def test_context_item_not_a_string_should_return_as_is():
@@ -476,9 +468,9 @@ def test_input_string_tag_not_in_context_should_throw():
         input_string = '{key1} this is {key2} string'
         context.get_formatted_string(input_string)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"Unable to format '{key1} this is {key2} "
-        "string' because key2 not found in the pypyr context.\",)")
+    assert str(err_info.value) == (
+        "Unable to format '{key1} this is {key2} "
+        "string' because key2 not found in the pypyr context.")
 
 
 def test_input_string_interpolate_sic():
@@ -495,9 +487,8 @@ def test_input_string_not_a_string_throw():
         input_string = 77
         context.get_formatted_string(input_string)
 
-    assert repr(err_info.value) == (
-        "TypeError(\"can only format on strings. 77 is a <class 'int'> "
-        "instead.\",)")
+    assert str(err_info.value) == (
+        "can only format on strings. 77 is a <class 'int'> instead.")
 
 
 def test_get_formatted_iterable_list():

--- a/tests/unit/pypyr/dsl_test.py
+++ b/tests/unit/pypyr/dsl_test.py
@@ -536,7 +536,7 @@ def test_while_error_kicks_loop(mock_invoke, mock_moduleloader):
         with pytest.raises(ValueError) as err_info:
             step.run_step(context)
 
-    assert repr(err_info.value) == ("ValueError('whoops',)")
+    assert str(err_info.value) == "whoops"
 
     assert mock_logger_info.mock_calls == [
         call('while decorator will loop 3 times at 0.0s intervals.'),
@@ -569,9 +569,8 @@ def test_while_exhausts(mock_invoke, mock_moduleloader):
         with pytest.raises(LoopMaxExhaustedError) as err_info:
             step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "LoopMaxExhaustedError('while loop reached "
-        "3 and {key5} never evaluated to True.',)")
+    assert str(err_info.value) == ("while loop reached "
+                                   "3 and {key5} never evaluated to True.")
 
     assert mock_logger_info.mock_calls == [
         call('while decorator will loop 3 times, or until {key5} evaluates to '
@@ -606,8 +605,7 @@ def test_while_exhausts_hard_true(mock_invoke, mock_moduleloader):
         with pytest.raises(LoopMaxExhaustedError) as err_info:
             step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "LoopMaxExhaustedError('while loop reached 3.',)")
+    assert str(err_info.value) == "while loop reached 3."
 
     assert mock_logger_info.mock_calls == [
         call('while decorator will loop 3 times at 0.0s intervals.'),
@@ -711,8 +709,7 @@ def test_invoke_step_no_run_step(mocked_moduleloader):
 
     mocked_moduleloader.assert_called_once_with('mocked.step')
 
-    assert repr(err_info.value) == (
-        "AttributeError(\"'int' object has no attribute 'run_step'\",)")
+    assert str(err_info.value) == "'int' object has no attribute 'run_step'"
 
 
 @patch('pypyr.moduleloader.get_module')
@@ -1573,7 +1570,7 @@ def test_run_pipeline_steps_complex_swallow_false_error(mock_invoke_step,
     with pytest.raises(ValueError) as err_info:
         step.run_step(context)
 
-        assert repr(err_info.value) == ("ValueError(\'arb error here',)")
+        assert str(err_info.value) == "arb error here"
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
@@ -1595,7 +1592,7 @@ def test_run_pipeline_steps_complex_swallow_defaults_false_error(
     with pytest.raises(ValueError) as err_info:
         step.run_step(context)
 
-        assert repr(err_info.value) == ("ValueError(\'arb error here',)")
+    assert str(err_info.value) == "arb error here"
 
     # validate all the in params ended up in context as intended
     assert len(context) == original_len
@@ -1612,8 +1609,7 @@ def test_run_pipeline_steps_simple_with_error(mock_invoke_step,
         with pytest.raises(ValueError) as err_info:
             step.run_step(Context({'k1': 'v1'}))
 
-            assert repr(err_info.value) == (
-                "ValueError(\'arb error here',)")
+            assert str(err_info.value) == "arb error here"
 
     mock_logger_debug.assert_any_call('step1 is a simple string.')
     mock_invoke_step.assert_called_once_with(
@@ -1720,9 +1716,8 @@ def test_while_init_not_a_dict():
     with pytest.raises(PipelineDefinitionError) as err_info:
         WhileDecorator('arb')
 
-    assert repr(err_info.value) == (
-        "PipelineDefinitionError('while decorator must be a dict (i.e a map) "
-        "type.',)")
+    assert str(err_info.value) == (
+        "while decorator must be a dict (i.e a map) type.")
 
 
 def test_while_init_no_max_no_stop():
@@ -1730,11 +1725,11 @@ def test_while_init_no_max_no_stop():
     with pytest.raises(PipelineDefinitionError) as err_info:
         WhileDecorator({'arb': 'arbv'})
 
-    assert repr(err_info.value) == (
-        'PipelineDefinitionError("the while decorator must have either max or '
-        'stop, or both. But not neither. Note that setting stop: False with '
-        'no max is an infinite loop. If an infinite loop is really what you '
-        'want, set stop: \'{ContextKeyWithFalseValue}\'",)')
+    assert str(err_info.value) == (
+        "the while decorator must have either max or "
+        "stop, or both. But not neither. Note that setting stop: False with "
+        "no max is an infinite loop. If an infinite loop is really what you "
+        "want, set stop: \'{ContextKeyWithFalseValue}\'")
 
 
 # ------------------- WhileDecorator: init -----------------------------------#
@@ -1860,9 +1855,9 @@ def test_while_loop_no_stop_no_max():
         wd.while_loop(Context(), mock)
 
     mock.assert_not_called()
-    assert repr(err_info.value) == (
-        "PipelineDefinitionError('the while decorator must have either max or "
-        "stop, or both. But not neither.',)")
+    assert str(err_info.value) == (
+        "the while decorator must have either max or "
+        "stop, or both. But not neither.")
 
 
 @patch('time.sleep')
@@ -2024,9 +2019,8 @@ def test_while_loop_stop_and_max_exhaust_error(mock_time_sleep):
             with pytest.raises(LoopMaxExhaustedError) as err_info:
                 wd.while_loop(context, mock_step)
 
-    assert repr(err_info.value) == (
-        "LoopMaxExhaustedError('while loop reached 3 and {k1} never evaluated "
-        "to True.',)")
+    assert str(err_info.value) == (
+        "while loop reached 3 and {k1} never evaluated to True.")
 
     assert context['whileCounter'] == 3
     assert step_count == 3
@@ -2080,8 +2074,7 @@ def test_while_loop_max_exhaust_error(mock_time_sleep):
             with pytest.raises(LoopMaxExhaustedError) as err_info:
                 wd.while_loop(context, mock_step)
 
-    assert repr(err_info.value) == (
-        "LoopMaxExhaustedError('while loop reached 3.',)")
+    assert str(err_info.value) == "while loop reached 3."
 
     assert context['whileCounter'] == 3
     assert step_count == 3

--- a/tests/unit/pypyr/errors_test.py
+++ b/tests/unit/pypyr/errors_test.py
@@ -19,8 +19,7 @@ def test_base_error_raises():
     with pytest.raises(PypyrError) as err_info:
         raise PypyrError("this is error text right here")
 
-    assert repr(err_info.value) == ("Error('this is error text "
-                                    "right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_context_error_raises():
@@ -30,8 +29,7 @@ def test_context_error_raises():
     with pytest.raises(ContextError) as err_info:
         raise ContextError("this is error text right here")
 
-    assert repr(err_info.value) == ("ContextError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_key_not_in_context_error_raises():
@@ -43,8 +41,7 @@ def test_key_not_in_context_error_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         raise KeyNotInContextError("this is error text right here")
 
-    assert repr(err_info.value) == ("KeyNotInContextError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_key_in_context_has_no_value_error_raises():
@@ -56,9 +53,7 @@ def test_key_in_context_has_no_value_error_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         raise KeyInContextHasNoValueError("this is error text right here")
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError('this is error "
-        "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_loop_max_exhausted_error_raises():
@@ -69,8 +64,7 @@ def test_loop_max_exhausted_error_raises():
     with pytest.raises(LoopMaxExhaustedError) as err_info:
         raise LoopMaxExhaustedError("this is error text right here")
 
-    assert repr(err_info.value) == ("LoopMaxExhaustedError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_pipeline_definition_error_raises():
@@ -81,8 +75,7 @@ def test_pipeline_definition_error_raises():
     with pytest.raises(PipelineDefinitionError) as err_info:
         raise PipelineDefinitionError("this is error text right here")
 
-    assert repr(err_info.value) == ("PipelineDefinitionError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_pipeline_not_found_error_raises():
@@ -93,8 +86,7 @@ def test_pipeline_not_found_error_raises():
     with pytest.raises(PipelineNotFoundError) as err_info:
         raise PipelineNotFoundError("this is error text right here")
 
-    assert repr(err_info.value) == ("PipelineNotFoundError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_plugin_error_raises():
@@ -105,8 +97,7 @@ def test_plugin_error_raises():
     with pytest.raises(PlugInError) as err_info:
         raise PlugInError("this is error text right here")
 
-    assert repr(err_info.value) == ("PlugInError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_pymodule_not_found_error_raises():
@@ -117,5 +108,4 @@ def test_pymodule_not_found_error_raises():
     with pytest.raises(PyModuleNotFoundError) as err_info:
         raise PyModuleNotFoundError("this is error text right here")
 
-    assert repr(err_info.value) == ("PyModuleNotFoundError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"

--- a/tests/unit/pypyr/moduleloader_test.py
+++ b/tests/unit/pypyr/moduleloader_test.py
@@ -103,7 +103,7 @@ def test_get_pipeline_path_raises():
     expected_msg = (f'unlikelypipeherexyz.yaml not found in either '
                     f'{current_path} or {pypyr_path}')
 
-    assert repr(err.value) == f'PipelineNotFoundError(\'{expected_msg}\',)'
+    assert str(err.value) == f"{expected_msg}"
 
 
 # ------------------------- get_pipeline_path --------------------------------#

--- a/tests/unit/pypyr/parser/list_test.py
+++ b/tests/unit/pypyr/parser/list_test.py
@@ -24,11 +24,11 @@ def test_empty_string_throw():
     with pytest.raises(AssertionError) as err_info:
         pypyr.parser.list.get_parsed_context(None)
 
-    assert repr(err_info.value) == (
-        "AssertionError(\"pipeline must be invoked with context arg set. For "
+    assert str(err_info.value) == (
+        "pipeline must be invoked with context arg set. For "
         "this list parser you're looking for something like: "
         "pypyr pipelinename 'spam,eggs' "
-        "OR: pypyr pipelinename 'spam'.\",)")
+        "OR: pypyr pipelinename 'spam'.")
 
 
 def test_builtin_list_still_works():

--- a/tests/unit/pypyr/parser/string_test.py
+++ b/tests/unit/pypyr/parser/string_test.py
@@ -22,10 +22,10 @@ def test_empty_string_throw():
     with pytest.raises(AssertionError) as err_info:
         pypyr.parser.string.get_parsed_context(None)
 
-    assert repr(err_info.value) == (
-        "AssertionError(\"pipeline must be invoked with context arg set. For "
+    assert str(err_info.value) == (
+        "pipeline must be invoked with context arg set. For "
         "this string parser you're looking for something "
-        "like: pypyr pipelinename 'spam and eggs'.\",)")
+        "like: pypyr pipelinename 'spam and eggs'.")
 
 
 def test_builtin_list_still_works():

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -77,9 +77,8 @@ def test_get_parser_context_signature_wrong(mocked_moduleloader):
         pypyr.pipelinerunner.get_parsed_context(
             {'context_parser': 'specifiedparserhere'}, 'in arg here')
 
-    assert repr(err_info.value) == (
-        "AttributeError(\"'int' object has no attribute "
-        "'get_parsed_context'\",)")
+    assert str(err_info.value) == ("'int' object has no attribute "
+                                   "'get_parsed_context'")
 
 # ------------------------- get_parsed_context--------------------------------#
 
@@ -147,8 +146,7 @@ def test_main_fail(mocked_work_dir, mocked_run_pipeline):
                                   log_level=77,
                                   log_path=None)
 
-    assert repr(err_info.value) == (
-        "ContextError('arb',)")
+    assert str(err_info.value) == "arb"
 
     mocked_work_dir.assert_called_once_with('arb/dir')
     mocked_run_pipeline.assert_called_once_with(

--- a/tests/unit/pypyr/steps/assert_test.py
+++ b/tests/unit/pypyr/steps/assert_test.py
@@ -42,8 +42,7 @@ def test_assert_raises_on_assertthis_false():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError('assert False evaluated to False.',)")
+    assert str(err_info.value) == "assert False evaluated to False."
 
 
 def test_assert_passes_on_assertthis_true():
@@ -82,8 +81,7 @@ def test_assert_raises_on_assertthis_false_string():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError('assert arb string evaluated to False.',)")
+    assert str(err_info.value) == "assert arb string evaluated to False."
 
 
 def test_assert_raises_on_assertthis_false_int():
@@ -92,8 +90,7 @@ def test_assert_raises_on_assertthis_false_int():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError('assert 0 evaluated to False.',)")
+    assert str(err_info.value) == "assert 0 evaluated to False."
 
 
 def test_assert_passes_on_assertthis_true_string():
@@ -109,9 +106,9 @@ def test_assert_raises_on_assertthis_not_equals():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type "
-        "str and does not equal context['assertEquals'] of type str.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type "
+        "str and does not equal context['assertEquals'] of type str.")
 
 
 def test_assert_passes_on_assertthis_equals():
@@ -142,9 +139,9 @@ def test_assert_raises_on_assertthis_not_equals_bools():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type bool and does "
-        "not equal context['assertEquals'] of type bool.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type bool and does "
+        "not equal context['assertEquals'] of type bool.")
 
 
 def test_assert_passes_on_assertthis_equals_ints():
@@ -161,9 +158,9 @@ def test_assert_raises_on_assertthis_not_equals_ints():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type int and does "
-        "not equal context['assertEquals'] of type int.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type int and does "
+        "not equal context['assertEquals'] of type int.")
 
 
 def test_assert_passes_on_assertthis_equals_floats():
@@ -180,9 +177,9 @@ def test_assert_raises_on_assertthis_not_equals_floats():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type float and "
-        "does not equal context['assertEquals'] of type float.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type float and "
+        "does not equal context['assertEquals'] of type float.")
 
 
 def test_assert_raises_on_assertthis_not_equals_string_to_int():
@@ -192,9 +189,9 @@ def test_assert_raises_on_assertthis_not_equals_string_to_int():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type str and does "
-        "not equal context['assertEquals'] of type int.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type str and does "
+        "not equal context['assertEquals'] of type int.")
 
 
 def test_assert_raises_on_assertthis_not_equals_string_to_bool():
@@ -204,9 +201,9 @@ def test_assert_raises_on_assertthis_not_equals_string_to_bool():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type bool and does "
-        "not equal context['assertEquals'] of type str.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type bool and does "
+        "not equal context['assertEquals'] of type str.")
 
 
 def test_assert_passes_on_assertthis_equals_lists():
@@ -223,9 +220,9 @@ def test_assert_raises_on_assertthis_not_equals_lists():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type list and does "
-        "not equal context['assertEquals'] of type list.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type list and does "
+        "not equal context['assertEquals'] of type list.")
 
 
 def test_assert_passes_on_assertthis_equals_dicts():
@@ -242,9 +239,9 @@ def test_assert_raises_on_assertthis_not_equals_dict_to_list():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type dict and does "
-        "not equal context['assertEquals'] of type list.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type dict and does "
+        "not equal context['assertEquals'] of type list.")
 
 
 def test_assert_raises_on_assertthis_not_equals_dict_to_dict():
@@ -254,9 +251,9 @@ def test_assert_raises_on_assertthis_not_equals_dict_to_dict():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type dict and does "
-        "not equal context['assertEquals'] of type dict.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type dict and does "
+        "not equal context['assertEquals'] of type dict.")
 
 # ---------------------- substitutions ----------------------------------------
 
@@ -279,9 +276,9 @@ def test_assert_raises_on_assertthis_not_equals_ints_substitutions():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type int and does "
-        "not equal context['assertEquals'] of type int.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type int and does "
+        "not equal context['assertEquals'] of type int.")
 
 
 def test_assert_passes_on_assertthis_not_equals_bools_substitutions():
@@ -294,9 +291,9 @@ def test_assert_passes_on_assertthis_not_equals_bools_substitutions():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type bool and does "
-        "not equal context['assertEquals'] of type str.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type bool and does "
+        "not equal context['assertEquals'] of type str.")
 
 
 def test_assert_passes_on_assertthis_not_equals_none_substitutions():
@@ -334,8 +331,7 @@ def test_assert_raises_on_assertthis_bool_substitutions():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError('assert {k1} evaluated to False.',)")
+    assert str(err_info.value) == "assert {k1} evaluated to False."
 
 
 def test_assert_raises_on_assertthis_substitutions_int():
@@ -347,8 +343,7 @@ def test_assert_raises_on_assertthis_substitutions_int():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError('assert {k1} evaluated to False.',)")
+    assert str(err_info.value) == "assert {k1} evaluated to False."
 
 
 def test_assert_assertthis_int_1_is_true():
@@ -368,8 +363,7 @@ def test_assert_raises_on_assertthis_none_substitutions():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError('assert {k1} evaluated to False.',)")
+    assert str(err_info.value) == "assert {k1} evaluated to False."
 
 
 def test_assert_passes_on_assertthis_equals_dicts_substitutions():
@@ -413,6 +407,6 @@ def test_assert_raises_on_assertthis_not_equals_dict_to_dict_substitutions():
     with pytest.raises(ContextError) as err_info:
         assert_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "ContextError(\"assert context['assertThis'] is of type dict and does "
-        "not equal context['assertEquals'] of type dict.\",)")
+    assert str(err_info.value) == (
+        "assert context['assertThis'] is of type dict and does "
+        "not equal context['assertEquals'] of type dict.")

--- a/tests/unit/pypyr/steps/contextmerge_test.py
+++ b/tests/unit/pypyr/steps/contextmerge_test.py
@@ -18,10 +18,9 @@ def test_contextmerge_throws_on_contextset_missing():
     with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.contextmerge.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['contextMerge'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.contextmerge.\",)")
+    assert str(err_info.value) == ("context['contextMerge'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.contextmerge.")
 
 
 def test_contextmerge_pass_no_substitutions():

--- a/tests/unit/pypyr/steps/contextset_test.py
+++ b/tests/unit/pypyr/steps/contextset_test.py
@@ -16,10 +16,9 @@ def test_context_set_throws_on_contextset_missing():
     with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.contextset.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['contextSet'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.contextset.\",)")
+    assert str(err_info.value) == ("context['contextSet'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.contextset.")
 
 
 def test_context_set_pass():

--- a/tests/unit/pypyr/steps/contextsetf_test.py
+++ b/tests/unit/pypyr/steps/contextsetf_test.py
@@ -16,10 +16,9 @@ def test_contextsetf_throws_on_contextset_missing():
     with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.contextsetf.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['contextSetf'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.contextsetf.\",)")
+    assert str(err_info.value) == ("context['contextSetf'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.contextsetf.")
 
 
 def test_contextsetf_pass_no_substitutions():

--- a/tests/unit/pypyr/steps/default_test.py
+++ b/tests/unit/pypyr/steps/default_test.py
@@ -18,10 +18,9 @@ def test_contextdefault_throws_on_contextdefault_missing():
     with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.default.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['defaults'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.default.\",)")
+    assert str(err_info.value) == ("context['defaults'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.default.")
 
 
 def test_contextdefault_pass_no_substitutions():

--- a/tests/unit/pypyr/steps/echo_test.py
+++ b/tests/unit/pypyr/steps/echo_test.py
@@ -61,9 +61,9 @@ def test_echo_empty_context_fails():
     with pytest.raises(AssertionError) as err_info:
         pypyr.steps.echo.run_step(None)
 
-    assert repr(err_info.value) == ("AssertionError(\"context must be set for "
-                                    "echo. Did you set 'echoMe=text "
-                                    "here'?\",)")
+    assert str(err_info.value) == ("context must be set for "
+                                   "echo. Did you set 'echoMe=text "
+                                   "here'?")
 
 
 def test_echo_missing_echo_me_raises():
@@ -73,9 +73,9 @@ def test_echo_missing_echo_me_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.echo.run_step(context)
 
-    assert repr(err_info.value) == ("KeyNotInContextError(\"context['echoMe'] "
-                                    "doesn't exist. It must exist for "
-                                    "pypyr.steps.echo.\",)")
+    assert str(err_info.value) == ("context['echoMe'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.echo.")
 
 
 def test_echo_echo_me_none_pass():

--- a/tests/unit/pypyr/steps/env_test.py
+++ b/tests/unit/pypyr/steps/env_test.py
@@ -13,8 +13,8 @@ def test_env_throws_on_empty_context():
     with pytest.raises(AssertionError) as err_info:
         pypyr.steps.env.run_step(None)
 
-    assert repr(err_info.value) == ("AssertionError('context must have value "
-                                    "for pypyr.steps.env',)")
+    assert str(err_info.value) == ("context must have value "
+                                   "for pypyr.steps.env")
 
 
 def test_env_throws_if_all_env_context_missing():
@@ -22,9 +22,9 @@ def test_env_throws_if_all_env_context_missing():
     with pytest.raises(AssertionError) as err_info:
         pypyr.steps.env.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == ("AssertionError('context must contain "
-                                    "any combination of envGet, envSet or "
-                                    "envUnset for pypyr.steps.env',)")
+    assert str(err_info.value) == ("context must contain "
+                                   "any combination of envGet, envSet or "
+                                   "envUnset for pypyr.steps.env")
 
 
 def test_env_throws_if_env_context_wrong_type():
@@ -33,9 +33,9 @@ def test_env_throws_if_env_context_wrong_type():
         pypyr.steps.env.run_step(
             Context({'envSet': 'it shouldnt be a string'}))
 
-    assert repr(err_info.value) == ("AssertionError('context must contain "
-                                    "any combination of envGet, envSet or "
-                                    "envUnset for pypyr.steps.env',)")
+    assert str(err_info.value) == ("context must contain "
+                                   "any combination of envGet, envSet or "
+                                   "envUnset for pypyr.steps.env")
 
 
 def test_env_only_calls_get():
@@ -224,7 +224,7 @@ def test_envget_env_doesnt_exist():
     with pytest.raises(KeyError) as err_info:
         pypyr.steps.env.env_get(context)
 
-    assert repr(err_info.value) == ("KeyError('ARB_DELETE_ME1',)")
+    assert str(err_info.value) == "'ARB_DELETE_ME1'"
     del os.environ['ARB_DELETE_ME2']
 # ------------------------- envGet -------------------------------------------#
 

--- a/tests/unit/pypyr/steps/fetchjson_test.py
+++ b/tests/unit/pypyr/steps/fetchjson_test.py
@@ -13,10 +13,9 @@ def test_fetchjson_no_path_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filefetcher.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fetchJsonPath'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fetchjson.\",)")
+    assert str(err_info.value) == ("context['fetchJsonPath'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fetchjson.")
 
 
 def test_fetchjson_empty_path_raises():
@@ -27,9 +26,8 @@ def test_fetchjson_empty_path_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filefetcher.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fetchJsonPath'] must have a "
-        "value for pypyr.steps.fetchjson.\",)")
+    assert str(err_info.value) == ("context['fetchJsonPath'] must have a "
+                                   "value for pypyr.steps.fetchjson.")
 
 
 def test_json_pass():

--- a/tests/unit/pypyr/steps/fetchyaml_test.py
+++ b/tests/unit/pypyr/steps/fetchyaml_test.py
@@ -13,10 +13,9 @@ def test_fetchyaml_no_path_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filefetcher.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fetchYamlPath'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fetchyaml.\",)")
+    assert str(err_info.value) == ("context['fetchYamlPath'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fetchyaml.")
 
 
 def test_fetchyaml_empty_path_raises():
@@ -27,9 +26,8 @@ def test_fetchyaml_empty_path_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filefetcher.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fetchYamlPath'] must have a "
-        "value for pypyr.steps.fetchyaml.\",)")
+    assert str(err_info.value) == ("context['fetchYamlPath'] must have a "
+                                   "value for pypyr.steps.fetchyaml.")
 
 
 def test_fetchyaml_pass():

--- a/tests/unit/pypyr/steps/fileformat_test.py
+++ b/tests/unit/pypyr/steps/fileformat_test.py
@@ -14,10 +14,9 @@ def test_fileformat_no_inpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileFormatIn'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fileformat.\",)")
+    assert str(err_info.value) == ("context['fileFormatIn'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileformat.")
 
 
 def test_fileformat_empty_inpath_raises():
@@ -28,9 +27,8 @@ def test_fileformat_empty_inpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileFormatIn'] must have a "
-        "value for pypyr.steps.fileformat.\",)")
+    assert str(err_info.value) == ("context['fileFormatIn'] must have a "
+                                   "value for pypyr.steps.fileformat.")
 
 
 def test_fileformat_no_outpath_raises():
@@ -42,10 +40,9 @@ def test_fileformat_no_outpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileFormatOut'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fileformat.\",)")
+    assert str(err_info.value) == ("context['fileFormatOut'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileformat.")
 
 
 def test_fileformat_empty_outpath_raises():
@@ -57,9 +54,8 @@ def test_fileformat_empty_outpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileFormatOut'] must have a "
-        "value for pypyr.steps.fileformat.\",)")
+    assert str(err_info.value) == ("context['fileFormatOut'] must have a "
+                                   "value for pypyr.steps.fileformat.")
 
 
 def test_fileformat_pass_no_substitutions():

--- a/tests/unit/pypyr/steps/fileformatjson_test.py
+++ b/tests/unit/pypyr/steps/fileformatjson_test.py
@@ -15,10 +15,9 @@ def test_fileformatjson_no_inpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileFormatJsonIn'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fileformatjson.\",)")
+    assert str(err_info.value) == ("context['fileFormatJsonIn'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileformatjson.")
 
 
 def test_fileformatjson_empty_inpath_raises():
@@ -29,9 +28,8 @@ def test_fileformatjson_empty_inpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileFormatJsonIn'] must have "
-        "a value for pypyr.steps.fileformatjson.\",)")
+    assert str(err_info.value) == ("context['fileFormatJsonIn'] must have "
+                                   "a value for pypyr.steps.fileformatjson.")
 
 
 def test_fileformatjson_no_outpath_raises():
@@ -43,10 +41,9 @@ def test_fileformatjson_no_outpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileFormatJsonOut'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fileformatjson.\",)")
+    assert str(err_info.value) == ("context['fileFormatJsonOut'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileformatjson.")
 
 
 def test_fileformatjson_empty_outpath_raises():
@@ -58,9 +55,8 @@ def test_fileformatjson_empty_outpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileFormatJsonOut'] must have "
-        "a value for pypyr.steps.fileformatjson.\",)")
+    assert str(err_info.value) == ("context['fileFormatJsonOut'] must have "
+                                   "a value for pypyr.steps.fileformatjson.")
 
 
 def test_fileformatjson_pass_no_substitutions():

--- a/tests/unit/pypyr/steps/fileformatyaml_test.py
+++ b/tests/unit/pypyr/steps/fileformatyaml_test.py
@@ -15,10 +15,9 @@ def test_fileformatyaml_no_inpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileFormatYamlIn'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fileformatyaml.\",)")
+    assert str(err_info.value) == ("context['fileFormatYamlIn'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileformatyaml.")
 
 
 def test_fileformatyaml_empty_inpath_raises():
@@ -29,9 +28,8 @@ def test_fileformatyaml_empty_inpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileFormatYamlIn'] must have "
-        "a value for pypyr.steps.fileformatyaml.\",)")
+    assert str(err_info.value) == ("context['fileFormatYamlIn'] must have "
+                                   "a value for pypyr.steps.fileformatyaml.")
 
 
 def test_fileformatyaml_no_outpath_raises():
@@ -43,10 +41,9 @@ def test_fileformatyaml_no_outpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileFormatYamlOut'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.fileformatyaml.\",)")
+    assert str(err_info.value) == ("context['fileFormatYamlOut'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileformatyaml.")
 
 
 def test_fileformatyaml_empty_outpath_raises():
@@ -58,9 +55,8 @@ def test_fileformatyaml_empty_outpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         fileformat.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileFormatYamlOut'] must have "
-        "a value for pypyr.steps.fileformatyaml.\",)")
+    assert str(err_info.value) == ("context['fileFormatYamlOut'] must have "
+                                   "a value for pypyr.steps.fileformatyaml.")
 
 
 def test_fileformatyaml_pass_no_substitutions():

--- a/tests/unit/pypyr/steps/filereplace_test.py
+++ b/tests/unit/pypyr/steps/filereplace_test.py
@@ -15,10 +15,9 @@ def test_filereplace_no_inpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filereplace.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileReplaceIn'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.filereplace.\",)")
+    assert str(err_info.value) == ("context['fileReplaceIn'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.filereplace.")
 
 
 def test_filereplace_empty_inpath_raises():
@@ -29,9 +28,8 @@ def test_filereplace_empty_inpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filereplace.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileReplaceIn'] must have a "
-        "value for pypyr.steps.filereplace.\",)")
+    assert str(err_info.value) == ("context['fileReplaceIn'] must have a "
+                                   "value for pypyr.steps.filereplace.")
 
 
 def test_filereplace_no_outpath_raises():
@@ -43,10 +41,9 @@ def test_filereplace_no_outpath_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filereplace.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileReplaceOut'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.filereplace.\",)")
+    assert str(err_info.value) == ("context['fileReplaceOut'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.filereplace.")
 
 
 def test_filereplace_empty_outpath_raises():
@@ -58,9 +55,8 @@ def test_filereplace_empty_outpath_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filereplace.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileReplaceOut'] must have a "
-        "value for pypyr.steps.filereplace.\",)")
+    assert str(err_info.value) == ("context['fileReplaceOut'] must have a "
+                                   "value for pypyr.steps.filereplace.")
 
 
 def test_filereplace_no_replacepairs_raises():
@@ -73,10 +69,9 @@ def test_filereplace_no_replacepairs_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filereplace.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['fileReplacePairs'] "
-        "doesn't exist. It must exist for "
-        "pypyr.steps.filereplace.\",)")
+    assert str(err_info.value) == ("context['fileReplacePairs'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.filereplace.")
 
 
 def test_filereplace_empty_replacepairs_raises():
@@ -89,9 +84,8 @@ def test_filereplace_empty_replacepairs_raises():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filereplace.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['fileReplacePairs'] must have "
-        "a value for pypyr.steps.filereplace.\",)")
+    assert str(err_info.value) == ("context['fileReplacePairs'] must have "
+                                   "a value for pypyr.steps.filereplace.")
 
 # ------------------------ arg validation -------------------------------------
 

--- a/tests/unit/pypyr/steps/py_test.py
+++ b/tests/unit/pypyr/steps/py_test.py
@@ -56,9 +56,9 @@ def test_no_pycode_context_throw():
         context = Context({'blah': 'blah blah'})
         pypyr.steps.py.run_step(context)
 
-    assert repr(err_info.value) == ("KeyNotInContextError(\"context['pycode'] "
-                                    "doesn't exist. It must exist for "
-                                    "pypyr.steps.py.\",)")
+    assert str(err_info.value) == ("context['pycode'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.py.")
 
 
 def test_empty_pycode_context_throw():

--- a/tests/unit/pypyr/steps/pype_test.py
+++ b/tests/unit/pypyr/steps/pype_test.py
@@ -63,9 +63,9 @@ def test_pype_get_arguments_missing_pype():
     with pytest.raises(KeyNotInContextError) as err_info:
         pype.get_arguments(context)
 
-    assert repr(err_info.value) == ("KeyNotInContextError(\"context['pype'] "
-                                    "doesn't exist. It must exist for "
-                                    "pypyr.steps.pype.\",)")
+    assert str(err_info.value) == ("context['pype'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.pype.")
 
 
 def test_pype_get_arguments_missing_name():
@@ -75,10 +75,10 @@ def test_pype_get_arguments_missing_name():
     with pytest.raises(KeyNotInContextError) as err_info:
         pype.get_arguments(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"pypyr.steps.pype missing 'name' in the 'pype' "
+    assert str(err_info.value) == (
+        "pypyr.steps.pype missing 'name' in the 'pype' "
         "context item. You need to specify the pipeline name to run another "
-        "pipeline.\",)")
+        "pipeline.")
 
 
 def test_pype_get_arguments_name_empty():
@@ -88,9 +88,8 @@ def test_pype_get_arguments_name_empty():
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         pype.get_arguments(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"pypyr.steps.pype ['pype']['name'] "
-        "exists but is empty.\",)")
+    assert str(err_info.value) == ("pypyr.steps.pype ['pype']['name'] exists "
+                                   "but is empty.")
 # ------------------------ get_arguments --------------------------------------
 
 # ------------------------ run_step -------------------------------------------
@@ -229,7 +228,7 @@ def test_pype_use_parent_context_no_swallow(mock_run_pipeline):
         with pytest.raises(RuntimeError) as err_info:
             pype.run_step(context)
 
-        assert repr(err_info.value) == "RuntimeError('whoops',)"
+        assert str(err_info.value) == "whoops"
 
     mock_run_pipeline.assert_called_once_with(
         pipeline_name='pipe name',

--- a/tests/unit/pypyr/steps/safeshell_test.py
+++ b/tests/unit/pypyr/steps/safeshell_test.py
@@ -51,6 +51,6 @@ def test_empty_context_cmd_throw():
         context = Context({'blah': 'blah blah'})
         pypyr.steps.safeshell.run_step(context)
 
-    assert repr(err_info.value) == ("KeyNotInContextError(\"context['cmd'] "
-                                    "doesn't exist. It must exist for "
-                                    "pypyr.steps.safeshell.\",)")
+    assert str(err_info.value) == ("context['cmd'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.safeshell.")

--- a/tests/unit/pypyr/steps/shell_test.py
+++ b/tests/unit/pypyr/steps/shell_test.py
@@ -62,6 +62,6 @@ def test_empty_context_cmd_throw():
         context = Context({'blah': 'blah blah'})
         pypyr.steps.shell.run_step(context)
 
-    assert repr(err_info.value) == ("KeyNotInContextError(\"context['cmd'] "
-                                    "doesn't exist. It must exist for "
-                                    "pypyr.steps.shell.\",)")
+    assert str(err_info.value) == ("context['cmd'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.shell.")

--- a/tests/unit/pypyr/steps/tar_test.py
+++ b/tests/unit/pypyr/steps/tar_test.py
@@ -38,8 +38,7 @@ def test_tar_throws_on_empty_context():
     with pytest.raises(AssertionError) as err_info:
         pypyr.steps.tar.run_step(None)
 
-    assert repr(err_info.value) == ("AssertionError('context must have value "
-                                    "for pypyr.steps.tar',)")
+    assert str(err_info.value) == "context must have value for pypyr.steps.tar"
 
 
 def test_tar_throws_if_all_tar_context_missing():
@@ -47,10 +46,10 @@ def test_tar_throws_if_all_tar_context_missing():
     with pytest.raises(KeyNotInContextError) as err_info:
         pypyr.steps.tar.run_step(Context({'arbkey': 'arbvalue'}))
 
-    assert repr(err_info.value) == ("KeyNotInContextError(\"pypyr.steps.tar "
-                                    "couldn\'t find tarExtract in context. "
-                                    "This step needs any combination of "
-                                    "tarExtract or tarArchive in context.\",)")
+    assert str(err_info.value) == ("pypyr.steps.tar "
+                                   "couldn\'t find tarExtract in context. "
+                                   "This step needs any combination of "
+                                   "tarExtract or tarArchive in context.")
 
 
 def test_tar_throws_if_tar_context_wrong_type():
@@ -59,11 +58,11 @@ def test_tar_throws_if_tar_context_wrong_type():
         pypyr.steps.tar.run_step(
             Context({'tarExtract': 'it shouldnt be a string'}))
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"pypyr.steps.tar found tarExtract in "
+    assert str(err_info.value) == (
+        "pypyr.steps.tar found tarExtract in "
         "context, but it's not a <class 'list'>. "
         "This step needs any combination of "
-        "tarExtract or tarArchive in context.\",)")
+        "tarExtract or tarArchive in context.")
 
 
 def test_tar_throws_if_tar_context_no_value():
@@ -73,11 +72,11 @@ def test_tar_throws_if_tar_context_no_value():
             Context({'tarExtract': None,
                      'tarArchive': None}))
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"pypyr.steps.tar found tarExtract in "
+    assert str(err_info.value) == (
+        "pypyr.steps.tar found tarExtract in "
         "context but it doesn't have a value. "
         "This step needs any combination of "
-        "tarExtract or tarArchive in context.\",)")
+        "tarExtract or tarArchive in context.")
 
 
 def test_tar_only_calls_extract():

--- a/tests/unit/pypyr/stepsrunner_test.py
+++ b/tests/unit/pypyr/stepsrunner_test.py
@@ -482,8 +482,7 @@ def test_run_pipeline_steps_swallow_sequence(mock_invoke_step, mock_module):
                 with pytest.raises(ValueError) as err_info:
                     pypyr.stepsrunner.run_pipeline_steps(steps, context)
 
-                    assert repr(err_info.value) == (
-                        "ValueError(\'arb error here 6',)")
+                    assert str(err_info.value) == "arb error here 6"
 
     mock_logger_debug.assert_has_calls == [call('step1 is complex.'),
                                            call('step2 is complex.'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36,py37
 skipsdist = false
 
 [testenv:dev]
@@ -37,7 +37,7 @@ commands =
         # check-manifest --ignore tox.ini,tests*
         python setup.py check -m -r -s
         flake8 .
-        py.test {posargs:py.test} 
+        py.test {posargs:py.test}
 usedevelop = true
 
 [flake8]


### PR DESCRIPTION
- make unit tests compatible with py 3.7. This is really just one change because of this https://bugs.python.org/issue30399 In a nutshell, repr() on Exceptions used to return an extra comma at the end in <py3.7, it doesn't anymore.
- ci will run both 3.6 and 3.7 unit tests
- README updates for new --loglevel arg, substitutions and sic strings
- version 1.1.0