### PR TITLE
Shippable matrix only deploy on 3.7

### DIFF
--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 
 [bdist_wheel]
 universal = 0

--- a/shippable.yaml
+++ b/shippable.yaml
@@ -15,10 +15,10 @@ build:
     # tox ci flakes, tests and covs.
     - tox -e ci -- --cov=pypyr --cov-report xml:shippable/codecoverage/coverage.xml --junitxml=shippable/testresults/junitresults.xml tests
     # all checks cleared on master and this is a merge commit (branch is protected and not in the midst of a PR), tag for release.
-    - if [ "$IS_PULL_REQUEST" == false ] && [ "$BRANCH" == "master" ] ; then ./ops/shippable-tag-release.sh; fi
+    - if [ "$IS_PULL_REQUEST" == false ] && [ "$SHIPPABLE_PYTHON_VERSION" == "3.7" ] && [ "$BRANCH" == "master" ] ; then ./ops/shippable-tag-release.sh; fi
 
   on_success:
-    - if [ "$IS_RELEASE" = "true" ]; then ./ops/shippable-pypi-release.sh; fi;
+    - if [ "$IS_RELEASE" == "true" ] && [ "$SHIPPABLE_PYTHON_VERSION" == "3.7" ] ; then ./ops/shippable-pypi-release.sh; fi;
 
 integrations:
   key:


### PR DESCRIPTION
- no functional change. fix shippable deploy only to deploy to pypi on 3.7 build, rather than both 3.6 and 3.7
- version bump to 1.1.1