### PR TITLE
Add new function to load and run pipeline

### DIFF
--- a/tests/unit/pypyr/steps/safeshell_test.py
+++ b/tests/unit/pypyr/steps/safeshell_test.py
@@ -1,4 +1,5 @@
 """safeshell.py unit tests."""
+import platform
 from pypyr.context import Context
 from pypyr.errors import KeyNotInContextError
 import pypyr.steps.safeshell
@@ -40,8 +41,9 @@ def test_shell_sequence_with_string_interpolation():
 
 def test_shell_error_throws():
     """Shell process returning 1 should throw CalledProcessError"""
+    cmd = '/bin/false' if platform.system() != 'Darwin' else '/usr/bin/false'
     with pytest.raises(subprocess.CalledProcessError):
-        context = Context({'cmd': '/bin/false'})
+        context = Context({'cmd': cmd})
         context = pypyr.steps.safeshell.run_step(context)
 
 


### PR DESCRIPTION
Split run_pipeline function on two: 
- load_and_run_pipeline
- run_pipeline
The main reason is to add capability to call pipeline context directly. See example of use case inside issue #80 