### PR TITLE
flake8 october update breakages

### DIFF
--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -575,12 +575,12 @@ class Context(dict):
                             self.get_formatted_iterable(v))
                     elif types.are_all_this_type(tuple, current[k], v):
                         # concatenate tuples
-                        current[k] = (current[k] +
-                                      self.get_formatted_iterable(v))
+                        current[k] = (
+                            current[k] + self.get_formatted_iterable(v))
                     elif types.are_all_this_type(Set, current[k], v):
                         # join sets
-                        current[k] = (current[k] |
-                                      self.get_formatted_iterable(v))
+                        current[k] = (
+                            current[k] | self.get_formatted_iterable(v))
                     else:
                         # at this point it's not mergable nor a known iterable
                         current[k] = v

--- a/tox.ini
+++ b/tox.ini
@@ -42,4 +42,4 @@ usedevelop = true
 
 [flake8]
 exclude = .tox,*.egg,build,data,dist,.cache
-select = E,W,F
+select = E,W,F, C90


### PR DESCRIPTION
amend flake8 err where both w503 and w504 (linebreaks before operators). Breakage due to flake8 oct update.

http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html

Adding a default select switch to the flake8 select seems to do the job.