### PR TITLE
py strings ref #89. big refactor to use special tag directives.

### DIFF
--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -24,6 +24,7 @@ def get_module(module_abs_import):
 
     Raises:
         PyModuleNotFoundError: if module not found.
+
     """
     logger.debug("starting")
     logger.debug(f"loading module {module_abs_import}")
@@ -63,6 +64,7 @@ def get_pipeline_path(pipeline_name, working_directory):
     Raises:
         PipelineNotFoundError: if pipeline_name.yaml not found in working_dir
                                or in {pypyr install dir}/pipelines.
+
     """
     logger.debug("starting")
 
@@ -107,6 +109,7 @@ def set_working_directory(working_directory):
 
     Args:
         working_directory: string. path to add to sys.paths
+
     """
     logger.debug("starting")
 

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -8,7 +8,7 @@ import pypyr.context
 import pypyr.log.logger
 import pypyr.moduleloader
 import pypyr.stepsrunner
-import ruamel.yaml as yaml
+import pypyr.yaml
 
 # use pypyr logger to ensure loglevel is set correctly
 logger = logging.getLogger(__name__)
@@ -30,6 +30,7 @@ def get_parsed_context(pipeline, context_in_string):
     Raises:
         AttributeError: parser specified on pipeline missing get_parsed_context
                         function.
+
     """
     logger.debug("starting")
 
@@ -83,6 +84,7 @@ def get_pipeline_definition(pipeline_name, working_dir):
     Raises:
         FileNotFoundError: pipeline_name.yaml not found in the various pipeline
                            dirs.
+
     """
     logger.debug("starting")
 
@@ -93,8 +95,8 @@ def get_pipeline_definition(pipeline_name, working_dir):
     logger.debug(f"Trying to open pipeline at path {pipeline_path}")
     try:
         with open(pipeline_path) as yaml_file:
-            yaml_loader = yaml.YAML(typ='safe', pure=True)
-            pipeline_definition = yaml_loader.load(yaml_file)
+            pipeline_definition = pypyr.yaml.get_pipeline_yaml(
+                yaml_file)
             logger.debug(
                 f"found {len(pipeline_definition)} stages in pipeline.")
     except FileNotFoundError:
@@ -134,6 +136,7 @@ def main(
 
     Returns:
         None
+
     """
     pypyr.log.logger.set_root_logger(log_level, log_path)
 
@@ -163,6 +166,7 @@ def prepare_context(pipeline, context_in_string, context):
     Returns:
         None. The context instance to use for the pipeline run is contained
               in the context arg, it's not passed back as a function return.
+
     """
     logger.debug("starting")
 
@@ -205,8 +209,8 @@ def load_and_run_pipeline(pipeline_name,
 
     Returns:
         None
-    """
 
+    """
     logger.debug(f"you asked to run pipeline: {pipeline_name}")
     logger.debug(f"you set the initial context to: {pipeline_context_input}")
 
@@ -252,6 +256,7 @@ def run_pipeline(pipeline,
 
     Returns:
         None
+
     """
     logger.debug("starting")
 

--- a/pypyr/utils/expressions.py
+++ b/pypyr/utils/expressions.py
@@ -1,0 +1,33 @@
+"""Utility functions for evaluating expressions."""
+
+
+def eval_string(input_string, locals):
+    """Dynamically evaluates the input_string expression.
+
+    This provides dynamic python eval of an input expression. The return is
+    whatever the result of the expression is.
+
+    Use with caution: since input_string executes any arbitrary code object,
+    the potential for damage is great.
+
+    For reasons best known to eval(), it EAFPs the locals() look-up 1st and if
+    it raises a KeyNotFound error, moves on to globals.
+
+    This means if you pass in something like the pypyr context, the custom
+    KeyNotInContextError the pypyr context raises isn't caught, and thus eval
+    doesn't work.
+
+    Therefore, in order to be used as the locals arg, the pypyr context needs
+    to be initialized to a new dict like this:
+        out = eval_string('1==1', dict(context))
+
+    Args:
+        input_string: str. expression to evaluate.
+        locals: dict-like. Mapping object containing scope for eval.
+
+    Returns:
+        Whatever object results from the string expression valuation.
+
+    """
+    # empty globals arg will append __builtins__ by default
+    return eval(input_string, {}, locals)

--- a/pypyr/utils/types.py
+++ b/pypyr/utils/types.py
@@ -1,8 +1,4 @@
-""""Utility functions for type checking, conversion and handling."""
-import logging
-
-# pypyr logger means the log level will be set correctly and output formatted.
-logger = logging.getLogger(__name__)
+"""Utility functions for type checking, conversion and handling."""
 
 
 def are_all_this_type(type, *objects):
@@ -15,6 +11,28 @@ def are_all_this_type(type, *objects):
     Returns:
         True is all objects are instances of specified Type.
         False if any or all of the objects are not instances of Type.
+
     """
     # return true if all objects are instances of type
     return all(isinstance(object, type) for object in objects)
+
+
+def cast_to_type(obj, out_type):
+    """Cast obj to out_type if it's not out_type already.
+
+    If the obj happens to be out_type already, it just returns obj as is.
+
+    Args:
+        obj: input object
+        out_type: type.
+
+    Returns:
+        obj cast to out_type. Usual python conversion / casting rules apply.
+
+    """
+    in_type = type(obj)
+    if out_type is in_type:
+        # no need to cast.
+        return obj
+    else:
+        return out_type(obj)

--- a/pypyr/yaml.py
+++ b/pypyr/yaml.py
@@ -1,0 +1,30 @@
+"""yaml handling functions."""
+import ruamel.yaml as yamler
+from pypyr.dsl import PyString, SicString
+
+
+def get_pipeline_yaml(file):
+    """Return pipeline yaml from open file object.
+
+    Use specific custom representers to model the custom pypyr pipeline yaml
+    format, to load in special literal types like py and sic strings.
+
+    If looking to extend the pypyr pipeline syntax with special types, add
+    these to the tag_representers list.
+
+    Args:
+        file: open file-like object.
+
+    Returns:
+        dict-like representation of loaded yaml.
+
+    """
+    tag_representers = [PyString, SicString]
+
+    yaml_loader = yamler.YAML(typ='safe', pure=True)
+
+    for representer in tag_representers:
+        yaml_loader.register_class(representer)
+
+    pipeline_definition = yaml_loader.load(file)
+    return pipeline_definition

--- a/tests/unit/pypyr/utils/expressions_test.py
+++ b/tests/unit/pypyr/utils/expressions_test.py
@@ -1,0 +1,93 @@
+"""expressions.py unit tests."""
+
+from math import sqrt
+import pytest
+from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
+import pypyr.utils.expressions as expressions
+
+
+def test_simple_expr_none_dict():
+    """Simple expression passes, with no locals dict."""
+    assert expressions.eval_string('1+1', None) == 2
+
+
+def test_simple_expr_empty_dict():
+    """Simple expression passes, with no locals dict."""
+    out = expressions.eval_string('len("123456") < 5', {})
+    assert isinstance(out, bool)
+    assert not out
+
+
+def test_simple_expr_locals_dict():
+    """Simple expression passes, with locals dict."""
+    assert expressions.eval_string('sqrt(4)', {'sqrt': sqrt}) == 2
+
+
+def test_expr_dict_vars():
+    """Expression uses vars from input dict."""
+    assert expressions.eval_string('(k1 + k2)*2==10', {'k1': 2, 'k2': 3})
+
+
+def test_expr_dict_nested_vars():
+    """Expression uses nested vars from input dict."""
+    assert expressions.eval_string('k2[2]["k2.2"] == 1.23',
+                                   {'k1': 1,
+                                    'k2': [0,
+                                           1,
+                                           {'k2.2': 1.23}
+                                           ]
+                                    }
+                                   )
+
+
+def test_expr_evals_bool():
+    """Expression can work as a boolean type."""
+    out = expressions.eval_string("a", {'a': True})
+    assert isinstance(out, bool)
+    assert out
+
+
+def test_expr_evals_complex():
+    """Expression evaluates complex types."""
+    assert expressions.eval_string('{"a": "b"} == c', {'c': {'a': 'b'}})
+
+
+def test_expr_runtime_error():
+    """Expression raises expected type during runtime error."""
+    with pytest.raises(ZeroDivisionError):
+        expressions.eval_string('1/0', None)
+
+
+def test_expr_invalid_syntax():
+    """Expression raises when invalid sytntax on input."""
+    with pytest.raises(SyntaxError):
+        expressions.eval_string('invalid code here', None)
+
+
+def test_expr_var_doesnt_exist():
+    """Expression raises when variable not found in namespace."""
+    with pytest.raises(NameError):
+        expressions.eval_string('a', {'b': True})
+
+
+def test_expr_derived_dicts_fail():
+    """Derived dicts fail with eval.
+
+    For reasons best known to eval(), it EAFPs the locals() look-up 1st and if
+    it raises a KeyNotFound error, moves on to globals.
+
+    This means if you pass in something like the pypyr context, the custom
+    KeyNotInContextError the pypyr context raises isn't caught, and thus eval
+    doesn't work.
+
+    Therefore, before pypyr context needs to initialize a new dict(context) in
+    order to be used as the locals arg.
+
+    If this unit test fails, it means the functionality has changed and you can
+    get rid of the redundant dict creation when context get_eval_string invokes
+    expressions eval_string.
+    """
+    with pytest.raises(KeyNotInContextError):
+        assert expressions.eval_string(
+            'len([0,1,2])', Context({'k1': 'v1'})) == 3

--- a/tests/unit/pypyr/utils/types_test.py
+++ b/tests/unit/pypyr/utils/types_test.py
@@ -1,22 +1,50 @@
 """types.py unit tests."""
 import pypyr.utils.types as types
 
+# ----------------- are_all_this_type -----------------------------------------
+
 
 def test_all_objects_of_type():
-    """All of type should be True"""
+    """All of type should be True."""
     assert types.are_all_this_type(int, 1, 2, 3, 4)
 
 
 def test_none_objects_of_type():
-    """None of type should be False"""
+    """None of type should be False."""
     assert not types.are_all_this_type(str, 1, 2, 3, 4)
 
 
 def test_one_obj_of_type():
-    """Only 1 input of type should be True"""
+    """Only 1 input of type should be True."""
     assert types.are_all_this_type(bool, False)
 
 
 def test_some_objects_of_type():
-    """Odd one out should be False"""
+    """Odd one out should be False."""
     assert not types.are_all_this_type(str, 1, '2', 3, 4)
+
+# ----------------- END are_all_this_type--------------------------------------
+
+# ----------------- END are_all_this_type--------------------------------------
+
+
+def test_cast_to_type_with_conversion():
+    """In obj casts to out type."""
+    out = types.cast_to_type(12, str)
+    assert isinstance(out, str)
+    assert out == "12"
+
+
+def test_cast_to_type_not_needed():
+    """In obj is already out type, no conversion needed."""
+    out = types.cast_to_type(12, int)
+    assert isinstance(out, int)
+    assert out == 12
+
+
+def test_cast_to_type_str_to_bool():
+    """String to bool always true."""
+    out = types.cast_to_type('False', bool)
+    assert isinstance(out, bool)
+    assert out
+# ----------------- END are_all_this_type--------------------------------------

--- a/tests/unit/pypyr/yaml_test.py
+++ b/tests/unit/pypyr/yaml_test.py
@@ -1,0 +1,35 @@
+"""yaml.py unit tests."""
+import io
+import pytest
+import pypyr.yaml as pypyr_yaml
+
+
+def test_get_pipeline_yaml_simple():
+    """Pipeline yaml loads with simple yaml."""
+    file = io.StringIO('1: 2\n2: 3')
+    pipeline = pypyr_yaml.get_pipeline_yaml(file)
+
+    assert pipeline == {1: 2, 2: 3}
+
+
+def test_get_pipeline_yaml_custom_types():
+    """Pipeline yaml loads with custom types."""
+    file = io.StringIO('1: !sic "{12}"\n2: !py abs(-23)\n3: !sic\n4: !py')
+    pipeline = pypyr_yaml.get_pipeline_yaml(file)
+
+    assert len(pipeline) == 4
+    assert pipeline[1].get_value() == '{12}'
+    assert repr(pipeline[2]) == "PyString('abs(-23)')"
+    assert pipeline[2].value == 'abs(-23)'
+    assert pipeline[2].get_value({}) == 23
+    # empty sic
+    assert repr(pipeline[3]) == "SicString('')"
+    assert pipeline[3].get_value({}) == ''
+    # empty py
+    assert repr(pipeline[4]) == "PyString('')"
+
+    with pytest.raises(ValueError) as err:
+        pipeline[4].get_value({})
+        assert str(err.value) == (
+            '!py string expression is empty. It must be a valid python '
+            'expression instead.')


### PR DESCRIPTION
- pypyr dsl expanded to accept custom tag parsers for literal parsing. This simplifies and hardens how sic strings work - instead of relying on string-parsing on "[sic]" and the tricky use of quotes and double-quotes, now a structural yam tag identifies sic string, making it a whole lot simpler to write sic strings with special characters in them without escape sequences or having to deal with `"'\'{blah}\''"` style eye-bleeding messes.
- this is a relatively big refactor under the covers, and it's a breaking change to how sic strings. Justified because the improvement in ease of use is massive.
- introduce Py Strings. These allow dynamic eval of python expressions anywhere you can use a string formatting expression in a pipeline.
- minor enhancement to initialise whileCounter before loop runs, allowing py strings to use the new py strings in the stop condition.
- refactor to move yaml handling into its own module