### PR TITLE
pypyr v2.0.0 - [sic] strings breaking change

### DIFF
--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '1.2.1'
+__version__ = '2.0.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1
+current_version = 2.0.0
 
 [bdist_wheel]
 universal = 0

--- a/tox.ini
+++ b/tox.ini
@@ -41,5 +41,5 @@ commands =
 usedevelop = true
 
 [flake8]
-exclude = .tox,*.egg,build,data,dist,.cache
+exclude = .tox,*.egg,build,data,dist,.cache,.deployenv
 select = E,W,F, C90


### PR DESCRIPTION
- pypyr v2.0.0 release!
- BREAKING CHANGES:
   - [sic] strings are now a lot better. Instead of relying on string-parsing on "[sic]" and the tricky use of quotes and double-quotes, now a structural yam tag identifies sic string, making it a whole lot simpler to write sic strings with special characters in them without escape sequences or having to deal with "'\'{blah}\''" style eye-bleeding messes. This does mean, however, that old style "[sic]" strings won't work anymore.
- new features:
  - Py Strings. These allow dynamic eval of python expressions anywhere you can use a string formatting expression in a pipeline. Thank you to  @Reskov for the idea, and working through the scenarios and options!
  - Write yaml or json to disk using `pypyr.steps.filewriteyaml` and `pypyr.steps.filewritejson`
  - The yaml and json fetchers can now write their payloads to a specified context key, rather than to the root of context.
  - the usual updates to README and examples.