### PR TITLE
cmd out save to context. closes #71

### DIFF
--- a/pypyr/steps/cmd.py
+++ b/pypyr/steps/cmd.py
@@ -1,8 +1,8 @@
-"""pypyr step that executes a shell as a sub-process.
+"""pypyr step that executes a cmd as a sub-process.
 
-The command string must be formatted exactly as it would be when typed
-at the shell prompt. This includes, for example, quoting or backslash escaping
-filenames with spaces in them. The shell defaults to /bin/sh.
+You cannot use things like exit, return, shell pipes, filename wildcards,
+environment,variable expansion, and expansion of ~ to a user’s home
+directory.
 """
 import logging
 from pypyr.steps.dsl.cmd import CmdStep
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_step(context):
-    """Run shell command without shell interpolation.
+    """Run command, program or executable.
 
     Context is a dictionary or dictionary-like.
 
@@ -24,13 +24,9 @@ def run_step(context):
         run: str. mandatory. <<cmd string>> command + args to execute.
         save: bool. defaults False. save output to cmdOut.
 
-    Will execute command string in the shell as a sub-process.
-    The shell defaults to /bin/sh.
-    The context['cmd'] string must be formatted exactly as it would be when
-    typed at the shell prompt. This includes, for example, quoting or backslash
-    escaping filenames with spaces in them.
-    There is an exception to this: Escape curly braces: if you want a literal
-    curly brace, double it like {{ or }}.
+    Will execute the command string in the shell as a sub-process.
+    Escape curly braces: if you want a literal curly brace, double it like
+    {{ or }}.
 
     If save is True, will save the output to context as follows:
         cmdOut:
@@ -52,6 +48,6 @@ def run_step(context):
     """
     logger.debug("started")
 
-    CmdStep(name=__name__, context=context).run_step(is_shell=True)
+    CmdStep(name=__name__, context=context).run_step(is_shell=False)
 
     logger.debug("done")

--- a/pypyr/steps/dsl/cmd.py
+++ b/pypyr/steps/dsl/cmd.py
@@ -1,0 +1,126 @@
+"""pypyr step yaml definition for commands - domain specific language."""
+import shlex
+import subprocess
+import logging
+from pypyr.errors import ContextError
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+class CmdStep():
+    """A pypyr step that represents a command runner step.
+
+    This models a step that takes config like this:
+        cmd: <<cmd string>>
+
+        OR, as a dict
+        cmd:
+            run: str. mandatory. command + args to execute.
+            save: bool. defaults False. save output to cmdOut.
+
+    If save is True, will save the output to context as follows:
+        cmdOut:
+            returncode: 0
+            stdout: 'stdout str here. None if empty.'
+            stderr: 'stderr str here. None if empty.'
+
+    cmdOut.returncode is the exit status of the called process. Typically 0
+    means OK. A negative value -N indicates that the child was terminated by
+    signal N (POSIX only).
+
+    The run_step method does the actual work. init loads the yaml.
+    """
+
+    def __init__(self, name, context):
+        """Initialize the CmdStep.
+
+        The step config in the context dict looks like this:
+            cmd: <<cmd string>>
+
+            OR, as a dict
+            cmd:
+                run: str. mandatory. command + args to execute.
+                save: bool. optional. defaults False. save output to cmdOut.
+
+        Args:
+            name: Unique name for step. Likely __name__ of calling step.
+            context: pypyr.context.Context. Look for config in this context
+                     instance.
+
+        """
+        assert name, ("name parameter must exist for CmdStep.")
+        assert context, ("context param must exist for CmdStep.")
+        # this way, logs output as the calling step, which makes more sense
+        # to end-user than a mystery steps.dsl.blah logging output.
+        self.logger = logging.getLogger(name)
+
+        context.assert_key_has_value(key='cmd', caller=name)
+
+        self.context = context
+        self.is_save = False
+
+        cmd_config = context['cmd']
+
+        if isinstance(cmd_config, str):
+            self.cmd_text = context.get_formatted('cmd')
+            self.logger.debug(f"Processing command string: {cmd_config}")
+        elif isinstance(cmd_config, dict):
+            context.assert_child_key_has_value(parent='cmd',
+                                               child='run',
+                                               caller=name)
+            run_string = cmd_config['run']
+            self.cmd_text = context.get_formatted_string(run_string)
+            is_save = cmd_config.get('save', False)
+            self.is_save = context.get_formatted_as_type(is_save,
+                                                         out_type=bool)
+            self.logger.debug(f"Processing command string: {run_string}")
+        else:
+            raise ContextError(f"{name} cmd config should be either a simple "
+                               "string cmd='mycommandhere' or a dictionary "
+                               "cmd={'run': 'mycommandhere', 'save': False}.")
+
+    def run_step(self, is_shell):
+        """Run a command.
+
+        Runs a program or executable. If is_shell is True, executes the command
+        through the shell.
+
+        Args:
+            is_shell: bool. defaults False. Set to true to execute cmd through
+                      the default shell.
+        """
+        assert is_shell is not None, ("is_shell param must exist for CmdStep.")
+
+        # why? If shell is True, it is recommended to pass args as a string
+        # rather than as a sequence.
+        if is_shell:
+            args = self.cmd_text
+        else:
+            args = shlex.split(self.cmd_text)
+
+        if self.is_save:
+            completed_process = subprocess.run(args,
+                                               shell=is_shell,
+                                               # capture_output=True,only>py3.7
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE,
+                                               # text=True, only>=py3.7,
+                                               universal_newlines=True)
+            self.context['cmdOut'] = {
+                'returncode': completed_process.returncode,
+                'stdout': completed_process.stdout,
+                'stderr': completed_process.stderr
+            }
+
+            # when capture is true, output doesn't write to stdout
+            self.logger.info(f"stdout: {completed_process.stdout}")
+            if completed_process.stderr:
+                self.logger.error(f"stderr: {completed_process.stderr}")
+
+            # don't swallow the error, because it's the Step swallow decorator
+            # responsibility to decide to ignore or not.
+            completed_process.check_returncode()
+        else:
+            # check=True throws CalledProcessError if exit code != 0
+            subprocess.run(args, shell=is_shell, check=True)

--- a/tests/unit/pypyr/steps/cmd_step_test.py
+++ b/tests/unit/pypyr/steps/cmd_step_test.py
@@ -1,0 +1,97 @@
+"""cmd.py unit tests."""
+import platform
+from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError
+import pypyr.steps.cmd
+import pytest
+import subprocess
+
+
+def test_cmd_single_word():
+    """One word command works."""
+    context = Context({'cmd': 'date'})
+    pypyr.steps.cmd.run_step(context)
+
+
+def test_cmd_sequence():
+    """Sequence of commands work."""
+    context = Context({'cmd': 'touch deleteme.arb'})
+    pypyr.steps.cmd.run_step(context)
+
+    context = Context({'cmd': 'ls deleteme.arb'})
+    pypyr.steps.cmd.run_step(context)
+
+    context = Context({'cmd': 'rm -f deleteme.arb'})
+    pypyr.steps.cmd.run_step(context)
+
+
+def test_cmd_sequence_with_string_interpolation():
+    """Single command string works with string interpolation."""
+    context = Context({'fileName': 'deleteinterpolatedme.arb',
+                       'cmd': 'touch {fileName}'})
+    pypyr.steps.cmd.run_step(context)
+
+    context = Context({'cmd': 'ls deleteinterpolatedme.arb'})
+    pypyr.steps.cmd.run_step(context)
+
+    context = Context({'fileName': 'deleteinterpolatedme.arb',
+                       'cmd': 'rm -f {fileName}'})
+    pypyr.steps.cmd.run_step(context)
+
+
+def test_cmd_dict_input_sequence_with_string_interpolation():
+    """Single command string works with string interpolation."""
+    context = Context({'fileName': 'deleteinterpolatedme.arb',
+                       'cmd': {'run': 'touch {fileName}'}})
+    pypyr.steps.cmd.run_step(context)
+
+    context = Context({'cmd': 'ls deleteinterpolatedme.arb'})
+    pypyr.steps.cmd.run_step(context)
+
+    context = Context({'fileName': 'deleteinterpolatedme.arb',
+                       'cmd': 'rm -f {fileName}'})
+    pypyr.steps.cmd.run_step(context)
+    assert 'cmdOut' not in context
+
+
+def test_cmd_dict_input_sequence_with_string_interpolation_save_out():
+    """Single command string works with string interpolation."""
+    context = Context({'fileName': 'deleteinterpolatedme.arb',
+                       'cmd': {'run': 'echo blah',
+                               'save': True}})
+    pypyr.steps.cmd.run_step(context)
+
+    assert context['cmdOut']['returncode'] == 0
+    assert context['cmdOut']['stdout'] == 'blah\n'
+    assert not context['cmdOut']['stderr']
+
+
+def test_cmd_error_throws():
+    """Process returning 1 should throw CalledProcessError."""
+    cmd = '/bin/false' if platform.system() != 'Darwin' else '/usr/bin/false'
+    with pytest.raises(subprocess.CalledProcessError):
+        context = Context({'cmd': cmd})
+        pypyr.steps.cmd.run_step(context)
+
+
+def test_cmd_error_throws_with_save_true():
+    """Process returning 1 should throw CalledProcessError."""
+    cmd = '/bin/cat xblahx'
+    with pytest.raises(subprocess.CalledProcessError):
+        context = Context({'cmd': {'run': cmd, 'save': True}})
+        pypyr.steps.cmd.run_step(context)
+
+    assert context['cmdOut']['returncode'] == 1
+    assert not context['cmdOut']['stdout']
+    assert 'xblahx: No such file or directory\n' in context['cmdOut']['stderr']
+
+
+def test_cmd_context_cmd_throw():
+    """Empty cmd in context should throw assert error."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        context = Context({'blah': 'blah blah'})
+        pypyr.steps.cmd.run_step(context)
+
+    assert str(err_info.value) == ("context['cmd'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.cmd.")

--- a/tests/unit/pypyr/steps/dsl/cmd_test.py
+++ b/tests/unit/pypyr/steps/dsl/cmd_test.py
@@ -1,0 +1,349 @@
+"""cmd.py unit tests."""
+import logging
+import pytest
+import subprocess
+from unittest.mock import patch
+from pypyr.context import Context
+from pypyr.errors import (ContextError,
+                          KeyInContextHasNoValueError,
+                          KeyNotInContextError)
+from pypyr.steps.dsl.cmd import CmdStep
+
+# ------------------------- FileInRewriterStep -------------------------------
+
+
+def test_cmdstep_name_required():
+    """Cmd Step requires name."""
+    with pytest.raises(AssertionError):
+        CmdStep(None, None)
+
+
+def test_cmdstep_context_required():
+    """Cmd Step requires context."""
+    with pytest.raises(AssertionError):
+        CmdStep('blah', None)
+
+
+def test_cmdstep_context_cmd_required():
+    """Cmd Step requires cmd in context."""
+    with pytest.raises(KeyNotInContextError) as err:
+        CmdStep('blah', Context({'a': 'b'}))
+
+    assert str(err.value) == ("context['cmd'] doesn't exist. It must exist "
+                              "for blah.")
+
+
+def test_cmdstep_context_cmd_not_none():
+    """Cmd Step requires cmd in context."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        CmdStep('blah', Context({'cmd': None}))
+
+    assert str(err.value) == "context['cmd'] must have a value for blah."
+
+
+def test_cmdstep_context_cmd_not_dict():
+    """Cmd Step requires cmd in context to be a dict if not str."""
+    with pytest.raises(ContextError) as err:
+        CmdStep('blah', Context({'cmd': 1}))
+
+    assert str(err.value) == (
+        "blah cmd config should be either a simple string cmd='mycommandhere' "
+        "or a dictionary cmd={'run': 'mycommandhere', 'save': False}.")
+
+
+def test_cmdstep_cmd_is_string():
+    """Str command is always not is_save."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': 'blah'}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': 'blah'})
+    assert obj.cmd_text == 'blah'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah')
+
+
+def test_cmdstep_cmd_is_dict_default_save_false():
+    """Dict command defaults not is_save."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': {'run': 'blah'}}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': {'run': 'blah'}})
+    assert obj.cmd_text == 'blah'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah')
+
+
+def test_cmdstep_cmd_is_dict_default_save_true():
+    """Dict command with is_save true."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': {'run': 'blah',
+                                                   'save': True}}))
+
+    assert obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': {'run': 'blah', 'save': True}})
+    assert obj.cmd_text == 'blah'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah')
+
+
+def test_cmdstep_runstep_cmd_is_string_shell_false():
+    """Str command is always not is_save."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': 'blah -blah1 --blah2'}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': 'blah -blah1 --blah2'})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah -blah1 --blah2')
+
+    with patch('subprocess.run') as mock_run:
+        obj.run_step(is_shell=False)
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with(['blah', '-blah1', '--blah2'],
+                                     shell=False, check=True)
+
+
+def test_cmdstep_runstep_cmd_is_string_formatting_shell_false():
+    """Str command is always not is_save and works with formatting."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'k1': 'blah',
+                                           'cmd': '{k1} -{k1}1 --{k1}2'}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'k1': 'blah',
+                                   'cmd': '{k1} -{k1}1 --{k1}2'})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: {k1} -{k1}1 --{k1}2')
+
+    with patch('subprocess.run') as mock_run:
+        obj.run_step(is_shell=False)
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with(['blah', '-blah1', '--blah2'],
+                                     shell=False, check=True)
+
+
+def test_cmdstep_runstep_cmd_is_string_shell_true():
+    """Str command is always not is_save."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': 'blah -blah1 --blah2'}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': 'blah -blah1 --blah2'})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah -blah1 --blah2')
+
+    with patch('subprocess.run') as mock_run:
+        obj.run_step(is_shell=True)
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with('blah -blah1 --blah2',
+                                     shell=True, check=True)
+
+
+def test_cmdstep_runstep_cmd_is_string_formatting_shell_true():
+    """Str command is always not is_save and works with formatting."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'k1': 'blah',
+                                           'cmd': '{k1} -{k1}1 --{k1}2'}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'k1': 'blah',
+                                   'cmd': '{k1} -{k1}1 --{k1}2'})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: {k1} -{k1}1 --{k1}2')
+
+    with patch('subprocess.run') as mock_run:
+        obj.run_step(is_shell=True)
+
+    # blah is a string because shell == true
+    mock_run.assert_called_once_with('blah -blah1 --blah2',
+                                     shell=True, check=True)
+
+
+def test_cmdstep_runstep_cmd_is_dict_save_false_shell_false():
+    """Dict command with save false and shell false."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': {
+            'run': 'blah -blah1 --blah2'}}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': {'run': 'blah -blah1 --blah2'}})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah -blah1 --blah2')
+
+    with patch('subprocess.run') as mock_run:
+        obj.run_step(is_shell=False)
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with(['blah', '-blah1', '--blah2'],
+                                     shell=False, check=True)
+
+
+def test_cmdstep_runstep_cmd_is_dict_save_false_shell_true():
+    """Dict command with save false and shell true."""
+    logger = logging.getLogger('blahname')
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', Context({'cmd': {
+            'run': 'blah -blah1 --blah2'}}))
+
+    assert not obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': {'run': 'blah -blah1 --blah2'}})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah -blah1 --blah2')
+
+    with patch('subprocess.run') as mock_run:
+        obj.run_step(is_shell=True)
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with('blah -blah1 --blah2',
+                                     shell=True, check=True)
+
+
+def test_cmdstep_runstep_cmd_is_dict_save_true_shell_false():
+    """Dict command with save false and shell false."""
+    logger = logging.getLogger('blahname')
+    context = Context({'cmd': {'run': 'blah -blah1 --blah2',
+                               'save': True}})
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', context)
+
+    assert obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': {'run': 'blah -blah1 --blah2',
+                                           'save': True}})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah -blah1 --blah2')
+
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(None,
+                                                            0,
+                                                            'std',
+                                                            'err')
+        with patch.object(logger, 'error') as mock_logger_error:
+            obj.run_step(is_shell=False)
+
+    mock_logger_error.assert_called_once_with('stderr: err')
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with(['blah', '-blah1', '--blah2'],
+                                     shell=False,
+                                     stderr=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     # text=True
+                                     universal_newlines=True)
+
+    assert context['cmdOut']['returncode'] == 0
+    assert context['cmdOut']['stdout'] == 'std'
+    assert context['cmdOut']['stderr'] == 'err'
+
+
+def test_cmdstep_runstep_cmd_is_dict_save_true_shell_true():
+    """Dict command with save false and shell true."""
+    logger = logging.getLogger('blahname')
+    context = Context({'cmd': {'run': 'blah -blah1 --blah2',
+                               'save': True}})
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', context)
+
+    assert obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'cmd': {'run': 'blah -blah1 --blah2',
+                                           'save': True}})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: blah -blah1 --blah2')
+
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(None,
+                                                            0,
+                                                            'std',
+                                                            None)
+        with patch.object(logger, 'info') as mock_logger_info:
+            obj.run_step(is_shell=True)
+
+    mock_logger_info.assert_called_once_with('stdout: std')
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with('blah -blah1 --blah2',
+                                     shell=True,
+                                     # capture_output=True,
+                                     stderr=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     # text=True,
+                                     universal_newlines=True)
+
+    assert context['cmdOut']['returncode'] == 0
+    assert context['cmdOut']['stdout'] == 'std'
+    assert context['cmdOut']['stderr'] is None
+
+
+def test_cmdstep_runstep_cmd_is_dict_save_true_shell_false_formatting():
+    """Dict command with save false and shell false with formatting."""
+    logger = logging.getLogger('blahname')
+    context = Context({'k1': 'blah',
+                       'k2': True,
+                       'cmd': {'run': '{k1} -{k1}1 --{k1}2',
+                               'save': '{k2}'}})
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        obj = CmdStep('blahname', context)
+
+    assert obj.is_save
+    assert obj.logger.name == 'blahname'
+    assert obj.context == Context({'k1': 'blah',
+                                   'k2': True,
+                                   'cmd': {'run': '{k1} -{k1}1 --{k1}2',
+                                           'save': '{k2}'}})
+    assert obj.cmd_text == 'blah -blah1 --blah2'
+    mock_logger_debug.assert_called_once_with(
+        'Processing command string: {k1} -{k1}1 --{k1}2')
+
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(None,
+                                                            0,
+                                                            'std',
+                                                            'err')
+        with patch.object(logger, 'error') as mock_logger_error:
+            obj.run_step(is_shell=False)
+
+    mock_logger_error.assert_called_once_with('stderr: err')
+
+    # blah is in a list because shell == false
+    mock_run.assert_called_once_with(['blah', '-blah1', '--blah2'],
+                                     shell=False,
+                                     # capture_output=True,
+                                     stderr=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     # text=True,
+                                     universal_newlines=True)
+
+    assert context['cmdOut']['returncode'] == 0
+    assert context['cmdOut']['stdout'] == 'std'
+    assert context['cmdOut']['stderr'] == 'err'

--- a/tests/unit/pypyr/steps/safeshell_test.py
+++ b/tests/unit/pypyr/steps/safeshell_test.py
@@ -55,4 +55,4 @@ def test_empty_context_cmd_throw():
 
     assert str(err_info.value) == ("context['cmd'] "
                                    "doesn't exist. It must exist for "
-                                   "pypyr.steps.safeshell.")
+                                   "pypyr.steps.cmd.")


### PR DESCRIPTION
* Shell/Safeshell can save stdout and stderr. ref #71 
* Add _pypyr.steps.cmd_ to replace .safeshell. Safeshell will still work as an alias. cmd is less confusing  vs _pypyr.steps.shell_