### PR TITLE
built-in context parsers optional args. closes #69

### DIFF
--- a/pypyr/parser/commas.py
+++ b/pypyr/parser/commas.py
@@ -14,11 +14,14 @@ logger = logging.getLogger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with context arg set. For "
-                         "this commas parser you're looking for something "
-                         "like: pypyr pipelinename 'spam,eggs' \n"
-                         "or: pypyr pipelinename 'spam'."
-                         )
+    if not context_arg:
+        logger.debug("pipeline invoked without context arg set. For "
+                     "this commas parser you're looking for something "
+                     "like: pypyr pipelinename 'spam,eggs' \n"
+                     "or: pypyr pipelinename 'spam'."
+                     )
+        return None
+
     logger.debug("starting")
     # for each comma-delimited element, project (element-name, true)
     return dict((element, True) for element in context_arg.split(','))

--- a/pypyr/parser/json.py
+++ b/pypyr/parser/json.py
@@ -9,11 +9,14 @@ logger = logging.getLogger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with context arg set. For "
-                         "this json parser you're looking for something "
-                         "like: "
-                         "pypyr pipelinename '{\"key1\":\"value1\","
-                         "\"key2\":\"value2\"}'")
+    if not context_arg:
+        logger.debug("pipeline invoked without context arg set. For "
+                     "this json parser you're looking for something "
+                     "like: "
+                     "pypyr pipelinename '{\"key1\":\"value1\","
+                     "\"key2\":\"value2\"}'")
+        return None
+
     logger.debug("starting")
     # deserialize the input context string into json
     return json.loads(context_arg)

--- a/pypyr/parser/keyvaluepairs.py
+++ b/pypyr/parser/keyvaluepairs.py
@@ -17,10 +17,13 @@ logger = logging.getLogger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with context arg set. For "
-                         "this keyvaluepairs parser you're looking for "
-                         "something like: "
-                         "pypyr pipelinename 'key1=value1,key2=value2'.")
+    if not context_arg:
+        logger.debug("pipeline invoked without context arg set. For "
+                     "this keyvaluepairs parser you're looking for "
+                     "something like: "
+                     "pypyr pipelinename 'key1=value1,key2=value2'.")
+        return None
+
     logger.debug("starting")
     # for each comma-delimited element, project key=value
     return dict(element.split('=') for element in context_arg.split(','))

--- a/pypyr/parser/list.py
+++ b/pypyr/parser/list.py
@@ -13,11 +13,14 @@ logger = logging.getLogger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with context arg set. For "
-                         "this list parser you're looking for something like: "
-                         "pypyr pipelinename 'spam,eggs' "
-                         "OR: pypyr pipelinename 'spam'."
-                         )
+    if not context_arg:
+        logger.debug("pipeline invoked without context arg set. For "
+                     "this list parser you're looking for something like: "
+                     "pypyr pipelinename 'spam,eggs' "
+                     "OR: pypyr pipelinename 'spam'."
+                     )
+        return {'argList': None}
+
     logger.debug("starting")
     # the list that's parsed from the input args is named argList
     return dict({'argList': context_arg.split(',')})

--- a/pypyr/parser/string.py
+++ b/pypyr/parser/string.py
@@ -14,10 +14,13 @@ logger = logging.getLogger(__name__)
 
 def get_parsed_context(context_arg):
     """Parse input context string and returns context as dictionary."""
-    assert context_arg, ("pipeline must be invoked with context arg set. For "
-                         "this string parser you're looking for something "
-                         "like: pypyr pipelinename 'spam and eggs'."
-                         )
+    if not context_arg:
+        logger.debug("pipeline invoked without context arg set. For "
+                     "this string parser you're looking for something "
+                     "like: pypyr pipelinename 'spam and eggs'."
+                     )
+        return {'argString': None}
+
     logger.debug("starting")
     # the list that's parsed from the input args is named argList
     return dict({'argString': context_arg})

--- a/tests/unit/pypyr/parser/commas_test.py
+++ b/tests/unit/pypyr/parser/commas_test.py
@@ -1,6 +1,5 @@
 """commas.py unit tests."""
 import pypyr.parser.commas
-import pytest
 
 
 def test_comma_string_parses_to_dict():
@@ -18,7 +17,7 @@ def test_no_commas_string_parses_to_single_entry():
     assert len(out) == 1, "1 item expected"
 
 
-def test_empty_string_throw():
-    """Empty input string should throw assert error."""
-    with pytest.raises(AssertionError):
-        pypyr.parser.commas.get_parsed_context(None)
+def test_empty_string_empty_dict():
+    """Empty input string should return empty dict."""
+    out = pypyr.parser.commas.get_parsed_context(None)
+    assert not out

--- a/tests/unit/pypyr/parser/json_test.py
+++ b/tests/unit/pypyr/parser/json_test.py
@@ -8,3 +8,9 @@ def test_json_cant_parse_from_arbitrary_string():
     """Comma delimited input string should fail."""
     with pytest.raises(json.JSONDecodeError):
         pypyr.parser.json.get_parsed_context('value 1,value 2, value3')
+
+
+def test_json_parser_empty_string_empty_dict():
+    """Empty inpout string creates empty dict."""
+    out = pypyr.parser.json.get_parsed_context(None)
+    assert not out

--- a/tests/unit/pypyr/parser/keyvaluepairs_test.py
+++ b/tests/unit/pypyr/parser/keyvaluepairs_test.py
@@ -29,7 +29,7 @@ def test_no_equals_string_parses_to_single_entry():
             'key1value2,value3')
 
 
-def test_empty_string_throw():
-    """Empty input string should throw assert error."""
-    with pytest.raises(AssertionError):
-        pypyr.parser.keyvaluepairs.get_parsed_context(None)
+def test_empty_string_empty_dict():
+    """Empty input string should returbn empty dict."""
+    out = pypyr.parser.keyvaluepairs.get_parsed_context(None)
+    assert not out

--- a/tests/unit/pypyr/parser/list_test.py
+++ b/tests/unit/pypyr/parser/list_test.py
@@ -1,6 +1,7 @@
 """list.py unit tests."""
+import logging
+from unittest.mock import patch
 import pypyr.parser.list
-import pytest
 
 
 def test_comma_string_parses_to_dict():
@@ -19,13 +20,16 @@ def test_no_commas_string_parses_to_single_entry():
     assert len(out['argList']) == 1, "1 item expected in argList"
 
 
-def test_empty_string_throw():
-    """Empty input string should throw assert error."""
-    with pytest.raises(AssertionError) as err_info:
-        pypyr.parser.list.get_parsed_context(None)
+def test_empty_string_empty_list():
+    """Empty input string should return empty list."""
+    logger = logging.getLogger('pypyr.parser.list')
 
-    assert str(err_info.value) == (
-        "pipeline must be invoked with context arg set. For "
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        out = pypyr.parser.list.get_parsed_context(None)
+
+    assert out['argList'] is None
+    mock_logger_debug.assert_called_once_with(
+        "pipeline invoked without context arg set. For "
         "this list parser you're looking for something like: "
         "pypyr pipelinename 'spam,eggs' "
         "OR: pypyr pipelinename 'spam'.")

--- a/tests/unit/pypyr/parser/string_test.py
+++ b/tests/unit/pypyr/parser/string_test.py
@@ -1,6 +1,7 @@
 """string.py unit tests."""
+import logging
+from unittest.mock import patch
 import pypyr.parser.string
-import pytest
 
 
 def test_comma_string_parses_to_dict():
@@ -19,11 +20,14 @@ def test_no_commas_string_parses_to_single_entry():
 
 def test_empty_string_throw():
     """Empty input string should throw assert error."""
-    with pytest.raises(AssertionError) as err_info:
-        pypyr.parser.string.get_parsed_context(None)
+    logger = logging.getLogger('pypyr.parser.string')
 
-    assert str(err_info.value) == (
-        "pipeline must be invoked with context arg set. For "
+    with patch.object(logger, 'debug') as mock_logger_debug:
+        out = pypyr.parser.string.get_parsed_context(None)
+
+    assert out['argString'] is None
+    mock_logger_debug.assert_called_once_with(
+        "pipeline invoked without context arg set. For "
         "this string parser you're looking for something "
         "like: pypyr pipelinename 'spam and eggs'.")
 


### PR DESCRIPTION
- make built-in context parsers input arguments optional to allow pipelines with context_parsers to be executed with or without an extra argument from the cmd line. ref #69 