### PR TITLE
Context must save behavior of dict on missing key.

### DIFF
--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -105,7 +105,7 @@ class PyString(SpecialTagDirective):
     def get_value(self, context):
         """Run python eval on the input string."""
         if self.value:
-            return expressions.eval_string(self.value, dict(context))
+            return expressions.eval_string(self.value, context)
         else:
             # Empty input raises cryptic EOF syntax err, this more human
             # friendly

--- a/pypyr/errors.py
+++ b/pypyr/errors.py
@@ -16,8 +16,11 @@ class KeyInContextHasNoValueError(ContextError):
     """pypyr context[key] doesn't have a value."""
 
 
-class KeyNotInContextError(ContextError):
+class KeyNotInContextError(ContextError, KeyError):
     """Key not found in the pypyr context."""
+    def __str__(self):
+        """KeyError has custom error formatting, avoid this behaviour."""
+        return super(Exception, self).__str__()
 
 
 class LoopMaxExhaustedError(Error):

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -79,6 +79,15 @@ def test_context_missing_override():
 
     with pytest.raises(KeyNotInContextError):
         context['notindict']
+
+
+def test_context_missing_raise_key_error():
+    """Context should raise error compatible with dict KeyError."""
+    context = Context({'arbkey': 'arbvalue'})
+
+    with pytest.raises(KeyError):
+        context['notindict']
+
 # ------------------- behaves like a dictionary-------------------------------#
 
 # ------------------- asserts ------------------------------------------------#

--- a/tests/unit/pypyr/utils/expressions_test.py
+++ b/tests/unit/pypyr/utils/expressions_test.py
@@ -3,7 +3,6 @@
 from math import sqrt
 import pytest
 from pypyr.context import Context
-from pypyr.errors import KeyNotInContextError
 import pypyr.utils.expressions as expressions
 
 
@@ -71,23 +70,6 @@ def test_expr_var_doesnt_exist():
         expressions.eval_string('a', {'b': True})
 
 
-def test_expr_derived_dicts_fail():
-    """Derived dicts fail with eval.
-
-    For reasons best known to eval(), it EAFPs the locals() look-up 1st and if
-    it raises a KeyNotFound error, moves on to globals.
-
-    This means if you pass in something like the pypyr context, the custom
-    KeyNotInContextError the pypyr context raises isn't caught, and thus eval
-    doesn't work.
-
-    Therefore, before pypyr context needs to initialize a new dict(context) in
-    order to be used as the locals arg.
-
-    If this unit test fails, it means the functionality has changed and you can
-    get rid of the redundant dict creation when context get_eval_string invokes
-    expressions eval_string.
-    """
-    with pytest.raises(KeyNotInContextError):
-        assert expressions.eval_string(
-            'len([0,1,2])', Context({'k1': 'v1'})) == 3
+def test_expr_func_when_context_as_locals():
+    """Expression should use built-in function when Context used as locals."""
+    assert expressions.eval_string('len([0,1,2])', Context({'k1': 'v1'})) == 3


### PR DESCRIPTION
`Context` must raise exception inherited from base `KeyError` class, when some key is not found at `Context` object.

The `test_expr_derived_dicts_fail` is not actual anymore.