### PR TITLE
pypyr.steps.getenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ Built-in context parsers
 |                             | with value to true.                             |This will create a context dictionary like this:                                     |
 |                             |                                                 |                                                                                     |
 |                             | Don't have spaces between commas unless you     |.. code-block:: python                                                               |
-|                             | really mean it. \"k1=v1, k2=v2\" will result in |                                                                                     |
+|                             | really mean it. \"k1, k2\" will result in       |                                                                                     |
 |                             | a context key name of \' k2\' not \'k2\'.       |  {'param1': True, 'param2': True, 'param3': True}                                   |
 +-----------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+
 | pypyr.parser.dict           | Takes a comma delimited key=value pair string   |``pypyr pipelinename "param1=value1,param2=value2,param3=value3"``                   |

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,8 @@ pypyr assumes a pipelines directory in your current working directory.
   $ pypyr mypipelinename --loglevel 10
 
   # run pipelines/mypipelinename.yaml with INFO logging level.
-  $ pypyr mypipelinename --logl 20
+  # log is an alias for loglevel, so less typing, wooohoo!
+  $ pypyr mypipelinename --log 20
 
   # If you don't specify --loglevel it defaults to 20 - INFO logging level.
   $ pypyr mypipelinename

--- a/README.rst
+++ b/README.rst
@@ -327,7 +327,11 @@ You can specify a step in the pipeline yaml in two ways:
 
       steps:
         - name: my.package.another.module
-          description: Optional Description is for humans. It's any yaml-escaped text that makes your life easier.
+          description: Optional Description is for humans.
+                       It is any yaml-escaped text that makes your life easier.
+                       Outputs to the console during runtime as INFO.
+          comment: Optional comments for pipeline developers.
+                   Does not output to console during run-time.
           in: #optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
             parameter1: value1
             parameter2: value2
@@ -350,8 +354,13 @@ Don't bother specifying these unless you want to deviate from the default values
 
   steps:
     - name: my.package.another.module
-      description: Optional Description is for humans. It's any yaml-escaped text that makes your life easier.
-      in: # optional. In parameters are added to the context so that this step and subsequent steps can use these key-value pairs.
+      description: Optional Description is for humans.
+                   Any yaml-escaped text that makes your life easier.
+                   Outputs to console during run-time.
+      comment: Optional comments for pipeline developers. Like code comments.
+               Does not output to console during run.
+      in: # optional. In parameters are added to the context.
+          # this step and subsequent steps can use these key-value pairs.
         parameter1: value1
         parameter2: value2
       foreach: [] # optional. Repeat the step once for each item in this list.

--- a/pypyr/cli.py
+++ b/pypyr/cli.py
@@ -31,7 +31,8 @@ def get_parser():
     parser.add_argument('--dir', dest='working_dir', default=os.getcwd(),
                         help='Working directory. Use if your pipelines '
                         'directory is elsewhere. Defaults to cwd.')
-    parser.add_argument('--loglevel', dest='log_level', type=int, default=20,
+    parser.add_argument('--log', '--loglevel', dest='log_level', type=int,
+                        default=20,
                         help='Integer log level. Defaults to 20 (INFO). '
                         '10=DEBUG\n20=INFO\n30=WARNING\n40=ERROR\n50=CRITICAL'
                         '.\n Log Level < 10 gives full traceback on errors.')

--- a/pypyr/pipelines/echo.yaml
+++ b/pypyr/pipelines/echo.yaml
@@ -3,7 +3,7 @@
 context_parser: pypyr.parser.string
 steps:
   - name: pypyr.steps.contextset
-    description: assign input arg to echoMe so echo step can echo it.
+    comment: assign input arg to echoMe so echo step can echo it
     in:
       contextSet:
         echoMe: argString

--- a/pypyr/pipelines/magritte.yaml
+++ b/pypyr/pipelines/magritte.yaml
@@ -2,6 +2,6 @@
 # pypyr magritte
 steps:
   - name: pypyr.steps.echo
-    description: Output echoMe
+    comment: output echoMe
     in:
       echoMe: Ceci n'est pas une pipe

--- a/pypyr/steps/envget.py
+++ b/pypyr/steps/envget.py
@@ -1,0 +1,114 @@
+"""Step that gets $ENVs, using a default value if the $ENV doesn't exist."""
+import os
+import logging
+from pypyr.errors import ContextError, KeyNotInContextError
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Get $ENVs, allowing a default if not found.
+
+    Set context properties from environment variables, and specify a default
+    if the environment variable is not found.
+
+    This differs from pypyr.steps.env get, which raises an error if attempting
+    to read an $ENV that doesn't exist.
+
+    Args:
+        context. mandatory. Context is a pypyr Context.
+
+    Input context is:
+        envGet:
+            - env: 'envvarnamehere'
+              key: 'savetocontexthere'
+              default: 'save this to key if env doesnt exist'
+
+    'env' is the bare environment variable name, do not put the $ in front of
+    it.
+
+    Will process as many env/key/default pairs as exist in the list under
+    envGet.
+
+    Returns:
+        None.
+
+    Raises:
+        ContextError: envGet is not a list of dicts.
+        KeyNotInContextError: envGet env or key doesn't exist.
+
+    """
+    logger.debug("started")
+    assert context, f"context must have value for {__name__}"
+
+    context.assert_key_has_value('envGet', __name__)
+
+    # allow a list OR a single getenv dict
+    if isinstance(context['envGet'], list):
+        get_items = context['envGet']
+    else:
+        get_items = [context['envGet']]
+
+    for get_me in get_items:
+        (env, key, has_default, default) = get_args(get_me)
+
+        logger.debug(f"setting context {key} to $ENV {env}")
+        formatted_key = context.get_formatted_string(key)
+        formatted_env = context.get_formatted_string(env)
+
+        if formatted_env in os.environ:
+            context[formatted_key] = os.environ[formatted_env]
+        else:
+            logger.debug(f"$ENV {env} not found.")
+            if has_default:
+                logger.debug(f"Using default value for {env} instead.")
+                formatted_default = context.get_formatted_iterable(default)
+                context[formatted_key] = os.environ.get(formatted_env,
+                                                        formatted_default)
+            else:
+                logger.debug(
+                    f"No default value for {env} found. Doin nuthin'.")
+
+
+def get_args(get_item):
+    """Parse env, key, default out of input dict.
+
+    Args:
+        get_item: dict. contains keys env/key/default
+
+    Returns:
+        (env, key, has_default, default) tuple, where
+            env: str. env var name.
+            key: str. save env value to this context key.
+            has_default: bool. True if default specified.
+            default: the value of default, if specified.
+
+    Raises:
+        ContextError: envGet is not a list of dicts.
+        KeyNotInContextError: If env or key not found in get_config.
+
+    """
+    if not isinstance(get_item, dict):
+        raise ContextError('envGet must contain a list of dicts.')
+
+    env = get_item.get('env', None)
+
+    if not env:
+        raise KeyNotInContextError(
+            'context envGet[env] must exist in context for envGet.')
+
+    key = get_item.get('key', None)
+
+    if not key:
+        raise KeyNotInContextError(
+            'context envGet[key] must exist in context for envGet.')
+
+    if 'default' in get_item:
+        has_default = True
+        default = get_item['default']
+    else:
+        has_default = False
+        default = None
+
+    return (env, key, has_default, default)

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.3.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -28,6 +28,54 @@ def test_main_pass_with_sysargv_context_positional():
         )
 
 
+def test_main_pass_with_sysargv_context_positional_log_alias():
+    """Invoke from cli sets sys.argv with log alias."""
+    arg_list = ['pypyr',
+                'blah',
+                'ctx string',
+                '--log',
+                '50',
+                '--dir',
+                'dir here']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            pypyr.cli.main()
+
+        mock_pipeline_main.assert_called_once_with(
+            pipeline_name='blah',
+            pipeline_context_input='ctx string',
+            working_dir='dir here',
+            log_level=50,
+            log_path=None
+        )
+
+
+def test_main_pass_with_sysargv_context_positional_abbreviations():
+    """Invoke from cli sets sys.argv with log abbreviations."""
+    arg_list = ['pypyr',
+                'blah',
+                'ctx string',
+                '--logl',
+                '50',
+                '--dir',
+                'dir here',
+                '--logp',
+                '/blah']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            pypyr.cli.main()
+
+        mock_pipeline_main.assert_called_once_with(
+            pipeline_name='blah',
+            pipeline_context_input='ctx string',
+            working_dir='dir here',
+            log_level=50,
+            log_path='/blah'
+        )
+
+
 def test_main_pass_with_sysargv_context_positional_flags_last():
     """Check assigns correctly to args when positional last not first."""
     arg_list = ['pypyr',

--- a/tests/unit/pypyr/steps/envget_test.py
+++ b/tests/unit/pypyr/steps/envget_test.py
@@ -1,0 +1,254 @@
+"""pypyr.steps.envget unit tests."""
+import os
+import pytest
+from pypyr.context import Context
+from pypyr.errors import ContextError, KeyNotInContextError
+import pypyr.steps.envget
+
+# ------------------------- run_step -----------------------------------------#
+
+
+def test_envget_throws_on_empty_context():
+    """Context must exist."""
+    with pytest.raises(AssertionError) as err_info:
+        pypyr.steps.envget.run_step(None)
+
+    assert str(err_info.value) == ("context must have value "
+                                   "for pypyr.steps.envget")
+
+
+def test_envget_throws_if_envget_context_missing():
+    """Env context keys must exist."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.envget.run_step(Context({'arbkey': 'arbvalue'}))
+
+    assert str(err_info.value) == ("context['envGet'] doesn't exist. It must "
+                                   "exist for pypyr.steps.envget.")
+
+
+def test_envget_throws_if_env_context_wrong_type():
+    """Env context keys must exist."""
+    with pytest.raises(ContextError) as err_info:
+        pypyr.steps.envget.run_step(
+            Context({'envGet': 'it shouldnt be a string'}))
+
+    assert str(err_info.value) == ("envGet must contain a list of dicts.")
+
+
+def test_envget_pass():
+    """Env get success case."""
+    os.environ['ARB_DELETE_ME1'] = 'arb value from $ENV ARB_DELETE_ME1'
+    os.environ['ARB_DELETE_ME2'] = 'arb value from $ENV ARB_DELETE_ME2'
+
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'envGet': [
+            {'env': 'ARB_DELETE_ME1',
+             'key': 'key2',
+             'default': 'blah'},
+            {'env': 'ARB_DELETE_ME2',
+             'key': 'key3'},
+            {'env': 'ARB_XXX_IDONTEXIST_BLAH',
+             'key': 'key4',
+             'default': 'blah4'},
+            {'env': 'ARB_XXX_IDONTEXIST_BLAH',
+             'key': 'key5'}
+        ]
+    })
+
+    pypyr.steps.envget.run_step(context)
+
+    del os.environ['ARB_DELETE_ME1']
+    del os.environ['ARB_DELETE_ME2']
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'arb value from $ENV ARB_DELETE_ME1'
+    assert context['key3'] == 'arb value from $ENV ARB_DELETE_ME2'
+    assert context['key4'] == 'blah4'
+    assert 'key5' not in context
+
+
+def test_envget_pass_single_item():
+    """Env get success case where single item not list passed."""
+    os.environ['ARB_DELETE_ME1'] = 'arb value from $ENV ARB_DELETE_ME1'
+
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'envGet':
+            {'env': 'ARB_DELETE_ME1',
+             'key': 'key2',
+             'default': 'blah'}
+    })
+
+    pypyr.steps.envget.run_step(context)
+
+    del os.environ['ARB_DELETE_ME1']
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'arb value from $ENV ARB_DELETE_ME1'
+    assert context['key3'] == 'value3'
+    assert 'key5' not in context
+
+
+def test_envget_pass_nones():
+    """Env get success case with none/nulls."""
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': 'value3',
+        'envGet': [
+            {'env': 'ARB_XXX_IDONTEXIST_BLAH',
+             'key': 'key4',
+             'default': None}
+        ]
+    })
+
+    pypyr.steps.envget.run_step(context)
+
+    assert context['key4'] is None
+
+
+def test_envget_pass_with_substitutions():
+    """Env get success case with string substitutions."""
+    os.environ['ARB_DELETE_ME1'] = 'arb value from $ENV ARB_DELETE_ME1'
+
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'env_val1': 'ARB_DELETE_ME1',
+        'env_val2': 'ARB_DELETE_ME2',
+        'default_val': 'blah',
+        'key_val': 'key3',
+        'envGet': [
+            {'env': '{env_val1}',
+             'key': '{key_val}',
+             'default': 'blah'},
+            {'env': '{env_val2}',
+             'key': 'key4',
+             'default': '{default_val}'}
+        ]
+    })
+
+    pypyr.steps.envget.run_step(context)
+
+    del os.environ['ARB_DELETE_ME1']
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'value2'
+    assert context['key3'] == 'arb value from $ENV ARB_DELETE_ME1'
+    assert context['key4'] == 'blah'
+
+
+def test_envget_pass_with_substitutions_default_not_string():
+    """Env get success case with substitutions that aren't string."""
+    os.environ['ARB_DELETE_ME1'] = 'arb value from $ENV ARB_DELETE_ME1'
+
+    context = Context({
+        'key1': 'value1',
+        'key2': 'value2',
+        'env_val1': 'ARB_DELETE_ME1',
+        'env_val2': 'ARB_DELETE_ME2',
+        'default_val': [0, 1, 2],
+        'key_val': 'key3',
+        'envGet': [
+            {'env': '{env_val1}',
+             'key': '{key_val}',
+             'default': 'blah'},
+            {'env': '{env_val2}',
+             'key': 'key4',
+             'default': '{default_val}'}
+        ]
+    })
+
+    pypyr.steps.envget.run_step(context)
+
+    del os.environ['ARB_DELETE_ME1']
+
+    assert context['key1'] == 'value1'
+    assert context['key2'] == 'value2'
+    assert context['key3'] == 'arb value from $ENV ARB_DELETE_ME1'
+    assert context['key4'] == [0, 1, 2]
+
+# ------------------------- get_args -----------------------------------------#
+
+
+def test_get_args_not_a_dict():
+    """Env context keys must exist."""
+    with pytest.raises(ContextError) as err_info:
+        pypyr.steps.envget.get_args('it shouldnt be a string')
+
+    assert str(err_info.value) == ("envGet must contain a list of dicts.")
+
+
+def test_get_args_env_exists():
+    """Env must exist."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.envget.get_args({'blah': 'blah'})
+
+    assert str(err_info.value) == (
+        "context envGet[env] must exist in context for envGet.")
+
+
+def test_get_args_empty_env_raises():
+    """Env must not be empty."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.envget.get_args({'env': None})
+
+    assert str(err_info.value) == (
+        "context envGet[env] must exist in context for envGet.")
+
+
+def test_get_args_key_exists():
+    """Key must exist."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.envget.get_args({'env': 'v'})
+
+    assert str(err_info.value) == (
+        "context envGet[key] must exist in context for envGet.")
+
+
+def test_get_args_empty_key_raises():
+    """Empty key must raise."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pypyr.steps.envget.get_args({'env': 'v', 'key': ''})
+
+    assert str(err_info.value) == (
+        "context envGet[key] must exist in context for envGet.")
+
+
+def test_get_args_no_default():
+    """Parses with no default set."""
+    (env, key, has_default, default) = pypyr.steps.envget.get_args(
+        {'env': 'e', 'key': 'k'})
+
+    assert env == 'e'
+    assert key == 'k'
+    assert not has_default
+    assert default is None
+
+
+def test_get_args_with_default():
+    """Parses with default set."""
+    (env, key, has_default, default) = pypyr.steps.envget.get_args(
+        {'env': 'e', 'key': 'k', 'default': 'blah'})
+
+    assert env == 'e'
+    assert key == 'k'
+    assert has_default
+    assert default == 'blah'
+
+
+def test_get_args_with_none_default():
+    """Parses with none default set."""
+    (env, key, has_default, default) = pypyr.steps.envget.get_args(
+        {'env': 'e', 'key': 'k', 'default': None})
+
+    assert env == 'e'
+    assert key == 'k'
+    assert has_default
+    assert default is None
+# ------------------------- END get_args -------------------------------------#


### PR DESCRIPTION
- add new step _pypyr.steps.getenv_ Whereas _pypyr.steps.env_ raises an error if you are getting an environment variable that doesn't exist, the new _envget_ allows you to specify a default value to use instead. ref #111 
- some documentation updates to demonstrate how to use py strings for ternary assignments
- built-in pypes use _comment_ rather than _description_ where output is not meant for operator consumption ref #109 
- alias the `--loglevel` switch with `--log`, so you can now do `pypyr mypipe --log 10` think of the savings just on keyboard wear and tear!
- new minor version release