### PR TITLE
pypyr.steps.pathcheck & deprecate multi-input fetches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -574,6 +574,8 @@ Built-in steps
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.filewriteyaml`_  | Write payload to file in yaml format.           | fileWriteYaml (dict)         |
 +-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.pathcheck`_      | Check if path exists on filesystem.             | pathCheck (string or dict)   |
++-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.py`_             | Executes the context value `pycode` as python   | pycode (string)              |
 |                               | code.                                           |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
@@ -1753,6 +1755,76 @@ the last line will substitute like this:
 
 See a worked `filewriteyaml example here
 <https://github.com/pypyr/pypyr-example/tree/master/pipelines/filewriteyaml.yaml>`_.
+
+pypyr.steps.pathcheck
+^^^^^^^^^^^^^^^^^^^^^
+Check if a path exists on the filesystem. Supports globbing. A path can point
+to a file or a directory.
+
+The ``pathCheck`` context key must exist.
+
+.. code-block:: yaml
+
+  - name: pypyr.steps.pathcheck
+    in:
+      pathCheck: ./**/*.py # single path with glob
+
+If you want to check for the existence of multiple paths, you can pass a list
+instead. You can freely mix literal paths and globs.
+
+.. code-block:: yaml
+
+  - name: pypyr.steps.pathcheck
+    in:
+      pathCheck:
+        - ./file1 # literal relative path
+        - ./dirname # also finds dirs
+        - ./**/{arbkey}* # glob with a string formatting expression
+
+After *pathcheck* completes, the ``pathCheckOut`` context key is available.
+This contains the results of the *pathcheck* operation.
+
+.. code-block:: yaml
+
+  pathCheckOut:
+      # the key is the ORIGINAL input, no string formatting applied.
+      'inpath-is-the-key': # one of these for each pathCheck input
+          exists: true # bool. True if path exists.
+          count: 0 # int. Number of files found for in path.
+          found: ['path1', 'path2'] # list of strings. Paths of files found.
+
+Example of passing a single input and the expected output context:
+
+.. code-block:: yaml
+
+  pathCheck: ./myfile # assuming ./myfile exists in $PWD
+  pathCheckOut:
+    './myfile':
+      exists: true,
+      count: 1,
+      found:
+        - './myfile'
+
+The ``exists`` and ``count`` keys can be very useful for conditional
+decorators to help decide whether to run subsequent steps. You can use these
+directly in string formatting expressions without any extra fuss.
+
+.. code-block:: yaml
+
+  - name: pypyr.steps.pathcheck
+    in:
+      pathCheck: ./**/*.arb
+  - name: pypyr.steps.echo
+    run: '{pathCheckOut[./**/*.arb][exists]}'
+    in:
+      echoMe: you'll only see me if ./**/*.arb found something on filesystem.
+
+All inputs support `Substitutions`_. This means you can specify another context
+item to be an individual path, or part of a path, or the entire path list.
+
+See a worked
+example for `pathcheck here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/pathcheck.yaml>`_.
 
 pypyr.steps.py
 ^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -557,7 +557,7 @@ Built-in steps
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.fetchjson`_      | Loads json file into pypyr context.             | fetchJson (dict)             |
 +-------------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.fetchyaml`_      | Loads yaml file into pypyr context.             | fetchYamlPath (path-like)    |
+| `pypyr.steps.fetchyaml`_      | Loads yaml file into pypyr context.             | fetchYaml (dict)             |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.fileformat`_     | Parse file and substitute {tokens} from         | fileFormat (dict)            |
 |                               | context.                                        |                              |
@@ -1339,14 +1339,19 @@ Loads a yaml file into the pypyr context.
 
 This step requires the following key in the pypyr context to succeed:
 
-- fetchYamlPath
+.. code-block:: yaml
 
-  - path-like. Path to file on disk. Can be relative.
+  fetchYaml:
+    path: ./path.yaml # required. path to file on disk. can be relative.
+    key: 'destinationKey' # optional. write yaml to this context key.
 
-- fetchYamlKey
+If ``key`` not specified, yaml writes directly to context root.
 
-  - Optional. Write yaml to this context key. If not specified, yaml writes
-    directly to context root.
+If you do not want to specify a key, you can also use the streamlined format:
+
+.. code-block:: yaml
+
+  fetchYaml: ./path.yaml # required. path to file on disk. can be relative.
 
 All inputs support `Substitutions`_.
 
@@ -1362,7 +1367,7 @@ I.e if file yaml has
 but context ``{'eggs': 'fried'}`` already exists, returned ``context['eggs']``
 will be 'boiled'.
 
-If *fetchYamlKey* is not specified, the yaml should not be a list at the top
+If ``key`` is not specified, the yaml should not be a list at the top
 level, but rather a mapping.
 
 So the top-level yaml should not look like this:

--- a/README.rst
+++ b/README.rst
@@ -555,7 +555,7 @@ Built-in steps
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.envget`_         | Get $ENVs and use a default if they don't exist.| envget (list)                |
 +-------------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.fetchjson`_      | Loads json file into pypyr context.             | fetchJsonPath (path-like)    |
+| `pypyr.steps.fetchjson`_      | Loads json file into pypyr context.             | fetchJson (dict)             |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.fetchyaml`_      | Loads yaml file into pypyr context.             | fetchYamlPath (path-like)    |
 +-------------------------------+-------------------------------------------------+------------------------------+
@@ -1308,14 +1308,19 @@ Loads a json file into the pypyr context.
 
 This step requires the following key in the pypyr context to succeed:
 
-- fetchJsonPath
+.. code-block:: yaml
 
-  - path-like. Path to file on disk. Can be relative.
+  fetchJson:
+    path: ./path.json # required. path to file on disk. can be relative.
+    key: 'destinationKey' # optional. write json to this context key.
 
-- fetchJsonKey
+If ``key`` is not specified, json writes directly to context root.
 
-  - Optional. Write json to this context key. If not specified, json writes
-    directly to context root.
+If you do not want to specify a key, you can also use the streamlined format:
+
+.. code-block:: yaml
+
+  fetchJson: ./path.json # required. path to file on disk. can be relative.
 
 All inputs support `Substitutions`_.
 
@@ -1325,7 +1330,7 @@ overwrite existing values if the same keys are already in there.
 I.e if file json has ``{'eggs' : 'boiled'}``, but context ``{'eggs': 'fried'}``
 already exists, returned ``context['eggs']`` will be 'boiled'.
 
-If *fetchJsonKey* is not specified, the json should not be an array [] at the
+If ``key`` is not specified, the json should not be an array [] at the
 root level, but rather an Object {}.
 
 pypyr.steps.fetchyaml

--- a/pypyr/steps/envget.py
+++ b/pypyr/steps/envget.py
@@ -50,6 +50,8 @@ def run_step(context):
     else:
         get_items = [context['envGet']]
 
+    get_count = 0
+
     for get_me in get_items:
         (env, key, has_default, default) = get_args(get_me)
 
@@ -59,6 +61,7 @@ def run_step(context):
 
         if formatted_env in os.environ:
             context[formatted_key] = os.environ[formatted_env]
+            get_count += 1
         else:
             logger.debug(f"$ENV {env} not found.")
             if has_default:
@@ -66,9 +69,12 @@ def run_step(context):
                 formatted_default = context.get_formatted_iterable(default)
                 context[formatted_key] = os.environ.get(formatted_env,
                                                         formatted_default)
+                get_count += 1
             else:
                 logger.debug(
                     f"No default value for {env} found. Doin nuthin'.")
+
+    logger.info(f"saved {get_count} $ENVs to context.")
 
 
 def get_args(get_item):

--- a/pypyr/steps/fetchjson.py
+++ b/pypyr/steps/fetchjson.py
@@ -96,5 +96,5 @@ def deprecated(context):
                        "are deprecated. They will stop working upon the next "
                        "major release. Use the new context key fetchJson "
                        "instead. It's a lot better, promise! For the moment "
-                       "pypyr is creating the new feetchJson key for you "
+                       "pypyr is creating the new fetchJson key for you "
                        "under the hood.")

--- a/pypyr/steps/pathcheck.py
+++ b/pypyr/steps/pathcheck.py
@@ -1,0 +1,83 @@
+"""pypyr step that checks if a file or directory path exists."""
+import logging
+from pypyr.errors import KeyInContextHasNoValueError
+import pypyr.utils.filesystem
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """pypyr step that checks if a file or directory path exists.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context key must exist
+                - pathsToCheck. str/path-like or list of str/paths.
+                                Path to file on disk to check.
+
+    All inputs support formatting expressions. Supports globs.
+
+    This step creates pathCheckOut in context, containing the results of the
+    path check operation.
+
+    pathCheckOut:
+        'inpath':
+            exists: true # bool. True if path exists.
+            count: 0 # int. Number of files found for in path.
+            found: ['path1', 'path2'] # list of strings. Paths of files found.
+
+    [count] is 0 if no files found. If you specified a single input
+    path to check and it exists, it's going to be 1. If you specified multiple
+    in paths or a glob expression that found more than 1 result, well, take a
+    guess.
+
+    [found] is a list of all the paths found for the [inpath]. If you passed
+    in a glob or globs, will contain the globs found for [inpath].
+
+    This means you can do an existence evaluation like this in a formatting
+    expression: '{pathCheckOut[inpathhere][exists]}'
+
+    Returns:
+        None. updates context arg.
+
+    Raises:
+        pypyr.errors.KeyNotInContextError: pathExists missing in context.
+        pypyr.errors.KeyInContextHasNoValueError: pathCheck exists but is None.
+
+    """
+    logger.debug("started")
+    context.assert_key_has_value(key='pathCheck', caller=__name__)
+
+    paths_to_check = context['pathCheck']
+
+    if not paths_to_check:
+        raise KeyInContextHasNoValueError("context['pathCheck'] must have a "
+                                          f"value for {__name__}.")
+
+    # pathsToCheck can be a string or a list in case there are multiple paths
+    if isinstance(paths_to_check, list):
+        check_me = paths_to_check
+    else:
+        # assuming it's a str/path at this point
+        check_me = [paths_to_check]
+
+    out = {}
+    total_found = 0
+
+    for path in check_me:
+        logger.debug(f"checking path: {path}")
+        formatted_path = context.get_formatted_string(path)
+        found_paths = pypyr.utils.filesystem.get_glob(formatted_path)
+        no_of_paths = len(found_paths)
+        out[path] = {
+            'exists': no_of_paths > 0,
+            'count': no_of_paths,
+            'found': found_paths
+        }
+        total_found = total_found + no_of_paths
+
+    context['pathCheckOut'] = out
+
+    logger.info(f'checked {len(out)} path(s) and found {total_found}')
+    logger.debug("done")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.4.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/integration/pypyr/steps/pathcheck_int_test.py
+++ b/tests/integration/pypyr/steps/pathcheck_int_test.py
@@ -1,0 +1,105 @@
+"""pathcheck.py integration tests."""
+import logging
+from unittest.mock import patch
+from pypyr.context import Context
+import pypyr.steps.pathcheck as pathchecker
+
+
+def test_pathcheck_list_none():
+    """Multiple paths ok with none returning match."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': ['./{ok1}/x', './arb/{ok1}', '{ok1}/arb/z']})
+
+    logger = logging.getLogger('pypyr.steps.pathcheck')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pathchecker.run_step(context)
+
+    mock_logger_info.assert_called_once_with('checked 3 path(s) and found 0')
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == ['./{ok1}/x', './arb/{ok1}', '{ok1}/arb/z']
+    assert context["pathCheckOut"] == {
+        './{ok1}/x': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+        './arb/{ok1}': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+        '{ok1}/arb/z': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+    }
+
+
+def test_pathcheck_single_with_formatting():
+    """Single path ok with string formatting."""
+    context = Context({
+        'ok1': 'arb',
+        'pathCheck': './tests/testfiles/glob/{ok1}.3'})
+
+    pathchecker.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'arb'
+    assert context['pathCheck'] == './tests/testfiles/glob/{ok1}.3'
+    assert context["pathCheckOut"] == {'./tests/testfiles/glob/{ok1}.3': {
+        'exists': True,
+        'count': 1,
+        'found': ['./tests/testfiles/glob/arb.3']
+    }}
+
+
+def test_pathcheck_list():
+    """Multiple paths ok with some returning no match."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': ['./tests/testfiles/glob/arb.1',
+                      './tests/testfiles/glob/arb.2*',
+                      './tests/testfiles/glob/arb.XX']})
+
+    logger = logging.getLogger('pypyr.steps.pathcheck')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pathchecker.run_step(context)
+
+    mock_logger_info.assert_called_once_with('checked 3 path(s) and found 3')
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == ['./tests/testfiles/glob/arb.1',
+                                    './tests/testfiles/glob/arb.2*',
+                                    './tests/testfiles/glob/arb.XX']
+
+    assert len(context["pathCheckOut"]) == 3
+
+    found = context["pathCheckOut"]['./tests/testfiles/glob/arb.1']
+    assert found
+    assert found['exists']
+    assert found['count'] == 1
+    assert found['found'] == ['./tests/testfiles/glob/arb.1']
+
+    found = context["pathCheckOut"]['./tests/testfiles/glob/arb.2*']
+    assert found
+    assert found['exists']
+    assert found['count'] == 2
+    frozen_actual_found = frozenset(found['found'])
+    frozen_expected_found = frozenset(['./tests/testfiles/glob/arb.2',
+                                       './tests/testfiles/glob/arb.2.2'])
+
+    assert frozen_actual_found == frozen_expected_found
+
+    found = context["pathCheckOut"]['./tests/testfiles/glob/arb.XX']
+    assert found
+    assert not found['exists']
+    assert found['count'] == 0
+    assert found['found'] == []

--- a/tests/unit/pypyr/steps/envget_test.py
+++ b/tests/unit/pypyr/steps/envget_test.py
@@ -1,6 +1,8 @@
 """pypyr.steps.envget unit tests."""
+import logging
 import os
 import pytest
+from unittest.mock import patch
 from pypyr.context import Context
 from pypyr.errors import ContextError, KeyNotInContextError
 import pypyr.steps.envget
@@ -58,10 +60,14 @@ def test_envget_pass():
         ]
     })
 
-    pypyr.steps.envget.run_step(context)
+    logger = logging.getLogger('pypyr.steps.envget')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pypyr.steps.envget.run_step(context)
 
     del os.environ['ARB_DELETE_ME1']
     del os.environ['ARB_DELETE_ME2']
+
+    mock_logger_info.assert_called_once_with('saved 3 $ENVs to context.')
 
     assert context['key1'] == 'value1'
     assert context['key2'] == 'arb value from $ENV ARB_DELETE_ME1'

--- a/tests/unit/pypyr/steps/fetchjson_test.py
+++ b/tests/unit/pypyr/steps/fetchjson_test.py
@@ -14,7 +14,7 @@ def test_fetchjson_no_path_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filefetcher.run_step(context)
 
-    assert str(err_info.value) == ("context['fetchJsonPath'] "
+    assert str(err_info.value) == ("context['fetchJson'] "
                                    "doesn't exist. It must exist for "
                                    "pypyr.steps.fetchjson.")
 
@@ -22,12 +22,13 @@ def test_fetchjson_no_path_raises():
 def test_fetchjson_empty_path_raises():
     """Empty path raises."""
     context = Context({
-        'fetchJsonPath': None})
+        'fetchJson': {
+            'path': None}})
 
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filefetcher.run_step(context)
 
-    assert str(err_info.value) == ("context['fetchJsonPath'] must have a "
+    assert str(err_info.value) == ("context['fetchJson']['path'] must have a "
                                    "value for pypyr.steps.fetchjson.")
 
 
@@ -38,14 +39,35 @@ def test_json_pass():
     """
     context = Context({
         'ok1': 'ov1',
-        'fetchJsonPath': './tests/testfiles/test.json'})
+        'fetchJson': {
+            'path': './tests/testfiles/test.json'}})
 
     filefetcher.run_step(context)
 
     assert context, "context shouldn't be None"
     assert len(context) == 5, "context should have 5 items"
     assert context['ok1'] == 'ov1'
-    assert context['fetchJsonPath'] == './tests/testfiles/test.json'
+    assert 'fetchJsonPath' not in context
+    assert context["key1"] == "value1", "key1 should be value2"
+    assert context["key2"] == "value2", "key2 should be value2"
+    assert context["key3"] == "value3", "key3 should be value2"
+
+
+def test_json_pass_with_string():
+    """Relative path to json should succeed with string input.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fetchJson': './tests/testfiles/test.json'})
+
+    filefetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 5, "context should have 5 items"
+    assert context['ok1'] == 'ov1'
+    assert 'fetchJsonPath' not in context
     assert context["key1"] == "value1", "key1 should be value2"
     assert context["key2"] == "value2", "key2 should be value2"
     assert context["key3"] == "value3", "key3 should be value2"
@@ -59,14 +81,15 @@ def test_json_pass_with_path_substitution():
     context = Context({
         'ok1': 'ov1',
         'fileName': 'test',
-        'fetchJsonPath': './tests/testfiles/{fileName}.json'})
+        'fetchJson': {
+            'path': './tests/testfiles/{fileName}.json'}})
 
     filefetcher.run_step(context)
 
     assert context, "context shouldn't be None"
     assert len(context) == 6, "context should have 6 items"
     assert context['ok1'] == 'ov1'
-    assert context['fetchJsonPath'] == './tests/testfiles/{fileName}.json'
+    assert 'fetchJsonPath' not in context
     assert context["key1"] == "value1", "key1 should be value2"
     assert context["key2"] == "value2", "key2 should be value2"
     assert context["key3"] == "value3", "key3 should be value2"
@@ -75,30 +98,84 @@ def test_json_pass_with_path_substitution():
 def test_fetchjson_with_destination():
     """Json writes to destination key."""
     context = Context({
-        'fetchJsonPath': '/arb/arbfile',
-        'fetchJsonKey': 'outkey'})
+        'fetchJson': {
+            'path': '/arb/arbfile',
+            'key': 'outkey'}})
 
     with patch('pypyr.steps.fetchjson.open', mock_open(read_data='[1,2,3]')):
         filefetcher.run_step(context)
 
     assert context['outkey'] == [1, 2, 3]
-    assert len(context) == 3
+    assert len(context) == 2
 
 
 def test_fetchjson_with_destination_int():
     """Json writes to destination key that's not a string."""
     context = Context({
-        'fetchJsonPath': '/arb/arbfile',
-        'fetchJsonKey': 99})
+        'fetchJson': {
+            'path': '/arb/arbfile',
+            'key': 99}})
 
     with patch('pypyr.steps.fetchjson.open', mock_open(read_data='[1,2,3]')):
         filefetcher.run_step(context)
 
     assert context[99] == [1, 2, 3]
-    assert len(context) == 3
+    assert len(context) == 2
 
 
 def test_fetchjson_with_destination_formatting():
+    """Json writes to destination key found by formatting expression."""
+    context = Context({
+        'keyhere': {'sub': ['outkey', 2, 3]},
+        'fetchJson': {
+            'path': '/arb/arbfile',
+            'key': '{keyhere[sub][0]}'}})
+
+    with patch('pypyr.steps.fetchjson.open', mock_open(
+            read_data='{"1": 2,"2": 3}')):
+        filefetcher.run_step(context)
+
+    assert len(context) == 3
+    assert context['outkey'] == {'1': 2, '2': 3}
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
+
+
+def test_fetchjson_list_fails():
+    """Json describing a list rather than a dict should fail if no outkey."""
+    context = Context({
+        'ok1': 'ov1',
+        'fetchJson': {
+            'path': '/arb/arbfile'}})
+
+    with patch('pypyr.steps.fetchjson.open', mock_open(read_data='[1,2,3]')):
+        with pytest.raises(TypeError):
+            filefetcher.run_step(context)
+
+# ---------------------- deprecated ------------------------------------------
+
+
+def test_json_pass_deprecated():
+    """Relative path to json should succeed.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fetchJsonPath': './tests/testfiles/test.json'})
+
+    filefetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 6, "context should have 6 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fetchJsonPath'] == './tests/testfiles/test.json'
+    assert context['fetchJson'] == {'path': './tests/testfiles/test.json'}
+    assert context["key1"] == "value1", "key1 should be value2"
+    assert context["key2"] == "value2", "key2 should be value2"
+    assert context["key3"] == "value3", "key3 should be value2"
+
+
+def test_fetchjson_with_destination_formatting_deprecated():
     """Json writes to destination key found by formatting expression."""
     context = Context({
         'keyhere': {'sub': ['outkey', 2, 3]},
@@ -109,19 +186,10 @@ def test_fetchjson_with_destination_formatting():
             read_data='{"1": 2,"2": 3}')):
         filefetcher.run_step(context)
 
-    assert len(context) == 4
+    assert len(context) == 5
     assert context['outkey'] == {'1': 2, '2': 3}
     assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
     assert context['fetchJsonPath'] == '/arb/arbfile'
     assert context['fetchJsonKey'] == '{keyhere[sub][0]}'
-
-
-def test_fetchjson_list_fails():
-    """Json describing a list rather than a dict should fail if no outkey."""
-    context = Context({
-        'ok1': 'ov1',
-        'fetchJsonPath': '/arb/arbfile'})
-
-    with patch('pypyr.steps.fetchjson.open', mock_open(read_data='[1,2,3]')):
-        with pytest.raises(TypeError):
-            filefetcher.run_step(context)
+    assert context['fetchJson'] == {'path': '/arb/arbfile',
+                                    'key': '{keyhere[sub][0]}'}

--- a/tests/unit/pypyr/steps/fetchyaml_test.py
+++ b/tests/unit/pypyr/steps/fetchyaml_test.py
@@ -14,7 +14,7 @@ def test_fetchyaml_no_path_raises():
     with pytest.raises(KeyNotInContextError) as err_info:
         filefetcher.run_step(context)
 
-    assert str(err_info.value) == ("context['fetchYamlPath'] "
+    assert str(err_info.value) == ("context['fetchYaml'] "
                                    "doesn't exist. It must exist for "
                                    "pypyr.steps.fetchyaml.")
 
@@ -22,12 +22,13 @@ def test_fetchyaml_no_path_raises():
 def test_fetchyaml_empty_path_raises():
     """Empty path raises."""
     context = Context({
-        'fetchYamlPath': None})
+        'fetchYaml': {
+            'path': None}})
 
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
         filefetcher.run_step(context)
 
-    assert str(err_info.value) == ("context['fetchYamlPath'] must have a "
+    assert str(err_info.value) == ("context['fetchYaml']['path'] must have a "
                                    "value for pypyr.steps.fetchyaml.")
 
 
@@ -36,42 +37,66 @@ def test_fetchyaml_pass():
 
     Strictly speaking not a unit test.
     """
+    context = Context({
+        'ok1': 'ov1',
+        'fetchYaml': {
+            'path': './tests/testfiles/dict.yaml'}})
 
+    filefetcher.run_step(context)
 
-context = Context({
-    'ok1': 'ov1',
-    'fetchYamlPath': './tests/testfiles/dict.yaml'})
-
-filefetcher.run_step(context)
-
-assert context, "context shouldn't be None"
-assert len(context) == 7, "context should have 7 items"
-assert context['ok1'] == 'ov1'
-assert context['fetchYamlPath'] == './tests/testfiles/dict.yaml'
-assert context['key2'] == 'value2', "key2 should be value2"
-assert len(context['key4']['k42']) == 3, "3 items in k42"
-assert 'k42list2' in context['key4']['k42'], "k42 containts k42list2"
-assert context['key4']['k43'], "k43 is True"
-assert context['key4']['k44'] == 77, "k44 is 77"
-assert len(context['key5']) == 2, "2 items in key5"
+    assert context, "context shouldn't be None"
+    assert len(context) == 7, "context should have 7 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fetchYaml']['path'] == './tests/testfiles/dict.yaml'
+    assert context['key2'] == 'value2', "key2 should be value2"
+    assert len(context['key4']['k42']) == 3, "3 items in k42"
+    assert 'k42list2' in context['key4']['k42'], "k42 containts k42list2"
+    assert context['key4']['k43'], "k43 is True"
+    assert context['key4']['k44'] == 77, "k44 is 77"
+    assert len(context['key5']) == 2, "2 items in key5"
 
 
 def test_fetchyaml_pass_with_substitution():
-    """Relative path to yaml should succeed with path subsitution.
+    """Relative path to yaml should succeed with path substitution.
 
     Strictly speaking not a unit test.
     """
     context = Context({
         'ok1': 'ov1',
         'fileName': 'dict',
-        'fetchYamlPath': './tests/testfiles/{fileName}.yaml'})
+        'fetchYaml': {
+            'path': './tests/testfiles/{fileName}.yaml'}})
 
     filefetcher.run_step(context)
 
     assert context, "context shouldn't be None"
     assert len(context) == 8, "context should have 8 items"
     assert context['ok1'] == 'ov1'
-    assert context['fetchYamlPath'] == './tests/testfiles/{fileName}.yaml'
+    assert context['fetchYaml']['path'] == './tests/testfiles/{fileName}.yaml'
+    assert context['key2'] == 'value2', "key2 should be value2"
+    assert len(context['key4']['k42']) == 3, "3 items in k42"
+    assert 'k42list2' in context['key4']['k42'], "k42 containts k42list2"
+    assert context['key4']['k43'], "k43 is True"
+    assert context['key4']['k44'] == 77, "k44 is 77"
+    assert len(context['key5']) == 2, "2 items in key5"
+
+
+def test_fetchyaml_pass_with_substitution_string():
+    """Relative path to yaml should succeed with path substitution.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fileName': 'dict',
+        'fetchYaml': './tests/testfiles/{fileName}.yaml'})
+
+    filefetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 8, "context should have 8 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fetchYaml'] == './tests/testfiles/{fileName}.yaml'
     assert context['key2'] == 'value2', "key2 should be value2"
     assert len(context['key4']['k42']) == 3, "3 items in k42"
     assert 'k42list2' in context['key4']['k42'], "k42 containts k42list2"
@@ -84,7 +109,7 @@ def test_fetchyaml_list_fails():
     """Yaml describing a list rather than a dict should fail."""
     context = Context({
         'ok1': 'ov1',
-        'fetchYamlPath': './tests/testfiles/list.yaml'})
+        'fetchYaml': './tests/testfiles/list.yaml'})
 
     with pytest.raises(TypeError):
         filefetcher.run_step(context)
@@ -93,42 +118,97 @@ def test_fetchyaml_list_fails():
 def test_fetchyaml_with_destination():
     """Yaml writes to destination key."""
     context = Context({
-        'fetchYamlPath': '/arb/arbfile',
-        'fetchYamlKey': 'outkey'})
+        'fetchYaml': {
+            'path': '/arb/arbfile',
+            'key': 'outkey'}})
 
-    with patch('pypyr.steps.fetchyaml.open', mock_open(read_data='[1,2,3]')):
+    with patch('pypyr.steps.fetchyaml.open', mock_open(
+            read_data='[1,2,3]')) as mock_file:
         filefetcher.run_step(context)
 
+    mock_file.assert_called_with('/arb/arbfile')
     assert context['outkey'] == [1, 2, 3]
-    assert len(context) == 3
+    assert len(context) == 2
 
 
 def test_fetchyaml_with_destination_int():
     """Yaml writes to destination key that's not a string."""
     context = Context({
-        'fetchYamlPath': '/arb/arbfile',
-        'fetchYamlKey': 99})
+        'fetchYaml': {
+            'path': '/arb/arbfile',
+            'key': 99}})
 
     with patch('pypyr.steps.fetchyaml.open', mock_open(read_data='[1,2,3]')):
         filefetcher.run_step(context)
 
     assert context[99] == [1, 2, 3]
-    assert len(context) == 3
+    assert len(context) == 2
 
 
 def test_fetchyaml_with_destination_formatting():
     """Yaml writes to destination key found by formatting expression."""
     context = Context({
-        'keyhere': {'sub': ['outkey', 2, 3]},
-        'fetchYamlPath': '/arb/arbfile',
+        'keyhere': {'sub': ['outkey', 2, 3], 'arbk': 'arbfile'},
+        'fetchYaml': {
+            'path': '/arb/{keyhere[arbk]}',
+            'key': '{keyhere[sub][0]}'}})
+
+    with patch('pypyr.steps.fetchyaml.open', mock_open(
+            read_data='1: 2\n2: 3')) as mock_file:
+        filefetcher.run_step(context)
+
+    mock_file.assert_called_with('/arb/arbfile')
+
+    assert len(context) == 3
+    assert context['outkey'] == {1: 2, 2: 3}
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3], 'arbk': 'arbfile'}
+    assert context['fetchYaml'] == {
+        'path': '/arb/{keyhere[arbk]}',
+        'key': '{keyhere[sub][0]}'}
+
+
+# ---------------------------- deprecated -------------------------------------
+def test_fetchyaml_pass_deprecated():
+    """Relative path to yaml should succeed.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fetchYamlPath': './tests/testfiles/dict.yaml'})
+
+    filefetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 8, "context should have 8 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fetchYamlPath'] == './tests/testfiles/dict.yaml'
+    assert context['fetchYaml'] == {'path': './tests/testfiles/dict.yaml'}
+    assert context['key2'] == 'value2', "key2 should be value2"
+    assert len(context['key4']['k42']) == 3, "3 items in k42"
+    assert 'k42list2' in context['key4']['k42'], "k42 containts k42list2"
+    assert context['key4']['k43'], "k43 is True"
+    assert context['key4']['k44'] == 77, "k44 is 77"
+    assert len(context['key5']) == 2, "2 items in key5"
+
+
+def test_fetchyaml_with_destination_formatting_deprecated():
+    """Yaml writes to destination key found by formatting expression."""
+    context = Context({
+        'keyhere': {'sub': ['outkey', 2, 3], 'arbk': 'arbfile'},
+        'fetchYamlPath': '/arb/{keyhere[arbk]}',
         'fetchYamlKey': '{keyhere[sub][0]}'})
 
     with patch('pypyr.steps.fetchyaml.open', mock_open(
-            read_data='1: 2\n2: 3')):
+            read_data='1: 2\n2: 3')) as mock_file:
         filefetcher.run_step(context)
 
-    assert len(context) == 4
+    mock_file.assert_called_with('/arb/arbfile')
+
+    assert len(context) == 5
     assert context['outkey'] == {1: 2, 2: 3}
-    assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
-    assert context['fetchYamlPath'] == '/arb/arbfile'
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3], 'arbk': 'arbfile'}
+    assert context['fetchYamlPath'] == '/arb/{keyhere[arbk]}'
     assert context['fetchYamlKey'] == '{keyhere[sub][0]}'
+    assert context['fetchYaml'] == {'path': '/arb/{keyhere[arbk]}',
+                                    'key': '{keyhere[sub][0]}'}

--- a/tests/unit/pypyr/steps/pathcheck_test.py
+++ b/tests/unit/pypyr/steps/pathcheck_test.py
@@ -1,0 +1,227 @@
+"""pathcheck.py unit tests."""
+import logging
+import pytest
+from unittest.mock import call, patch
+from pypyr.context import Context
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
+import pypyr.steps.pathcheck as pathchecker
+
+
+def test_pathcheck_no_input_raises():
+    """No input context raises."""
+    context = Context({
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        pathchecker.run_step(context)
+
+    assert str(err_info.value) == ("context['pathCheck'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.pathcheck.")
+
+
+def test_pathcheck_empty_path_raises():
+    """Empty path check raises."""
+    context = Context({
+        'pathCheck': None})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        pathchecker.run_step(context)
+
+    assert str(err_info.value) == ("context['pathCheck'] must have a "
+                                   "value for pypyr.steps.pathcheck.")
+
+
+def test_pathcheck_empty_string_path_raises():
+    """Empty string path check raises."""
+    context = Context({
+        'pathCheck': ''})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        pathchecker.run_step(context)
+
+    assert str(err_info.value) == ("context['pathCheck'] must have a "
+                                   "value for pypyr.steps.pathcheck.")
+
+
+def test_pathcheck_empty_path_list_raises():
+    """Empty path check list raises."""
+    context = Context({
+        'pathCheck': []})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        pathchecker.run_step(context)
+
+    assert str(err_info.value) == ("context['pathCheck'] must have a "
+                                   "value for pypyr.steps.pathcheck.")
+
+
+@patch('pypyr.utils.filesystem.get_glob')
+def test_pathcheck_single(mock_glob):
+    """Single path ok."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': './arb/x'})
+
+    mock_glob.return_value = ['./foundfile']
+
+    logger = logging.getLogger('pypyr.steps.pathcheck')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pathchecker.run_step(context)
+
+    mock_logger_info.assert_called_once_with('checked 1 path(s) and found 1')
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == './arb/x'
+    assert context["pathCheckOut"] == {'./arb/x': {
+        'exists': True,
+        'count': 1,
+        'found': ['./foundfile']
+    }}
+
+    mock_glob.assert_called_once_with('./arb/x')
+
+
+@patch('pypyr.utils.filesystem.get_glob')
+def test_pathcheck_single_not_found(mock_glob):
+    """Single path ok on not found."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': './arb/x'})
+
+    mock_glob.return_value = []
+
+    logger = logging.getLogger('pypyr.steps.pathcheck')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pathchecker.run_step(context)
+
+    mock_logger_info.assert_called_once_with('checked 1 path(s) and found 0')
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == './arb/x'
+    assert context["pathCheckOut"] == {'./arb/x': {
+        'exists': False,
+        'count': 0,
+        'found': []
+    }}
+
+    mock_glob.assert_called_once_with('./arb/x')
+
+
+@patch('pypyr.utils.filesystem.get_glob')
+def test_pathcheck_single_with_formatting(mock_glob):
+    """Single path ok with string formatting."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': './{ok1}/x'})
+
+    mock_glob.return_value = ['./foundfile']
+
+    pathchecker.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == './{ok1}/x'
+    assert context["pathCheckOut"] == {'./{ok1}/x': {
+        'exists': True,
+        'count': 1,
+        'found': ['./foundfile']
+    }}
+
+    mock_glob.assert_called_once_with('./ov1/x')
+
+
+@patch('pypyr.utils.filesystem.get_glob')
+def test_pathcheck_list(mock_glob):
+    """Multiple paths ok with some returning no match."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': ['./arb/x', './arb/y', './arb/z']})
+
+    mock_glob.side_effect = [
+        ['./f1.1'],
+        ['./f2.1', './f2.2', './f2.3'],
+        []
+    ]
+
+    logger = logging.getLogger('pypyr.steps.pathcheck')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pathchecker.run_step(context)
+
+    mock_logger_info.assert_called_once_with('checked 3 path(s) and found 4')
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == ['./arb/x', './arb/y', './arb/z']
+    assert context["pathCheckOut"] == {
+        './arb/x': {
+            'exists': True,
+            'count': 1,
+            'found': ['./f1.1']
+        },
+        './arb/y': {
+            'exists': True,
+            'count': 3,
+            'found': ['./f2.1', './f2.2', './f2.3']
+        },
+        './arb/z': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+    }
+
+    assert mock_glob.mock_calls == [call('./arb/x'),
+                                    call('./arb/y'),
+                                    call('./arb/z')]
+
+
+@patch('pypyr.utils.filesystem.get_glob')
+def test_pathcheck_list_none(mock_glob):
+    """Multiple paths ok with none returning match."""
+    context = Context({
+        'ok1': 'ov1',
+        'pathCheck': ['./{ok1}/x', './arb/{ok1}', '{ok1}/arb/z']})
+
+    mock_glob.side_effect = [
+        [],
+        [],
+        []
+    ]
+
+    logger = logging.getLogger('pypyr.steps.pathcheck')
+    with patch.object(logger, 'info') as mock_logger_info:
+        pathchecker.run_step(context)
+
+    mock_logger_info.assert_called_once_with('checked 3 path(s) and found 0')
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 3, "context should have 3 items"
+    assert context['ok1'] == 'ov1'
+    assert context['pathCheck'] == ['./{ok1}/x', './arb/{ok1}', '{ok1}/arb/z']
+    assert context["pathCheckOut"] == {
+        './{ok1}/x': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+        './arb/{ok1}': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+        '{ok1}/arb/z': {
+            'exists': False,
+            'count': 0,
+            'found': []
+        },
+    }
+
+    assert mock_glob.mock_calls == [call('./ov1/x'),
+                                    call('./arb/ov1'),
+                                    call('ov1/arb/z')]


### PR DESCRIPTION
- The new _pypyr.steps.pathcheck_ step allows you see if a path exists on the filesystem. It supports literal paths and glob expansions. It writes handy values into `pathCheckOut`with bool for existence and count of files found for the given path. #114 
- deprecate old style multi context inputs for fetchjson and fetchyaml, #118. this is not just arbitrary: reason is when step is used multiple times in same pipeline, it becomes easy to have left-over values from previous step run left in context that then cause surprising behaviour with the downstream step. the old style is still supported by virtue of pypyr creating the new style inputs under the hood if it finds the old style arguments - but you can expect this to go away by the next major release.
- add info output logging to envget