### PR TITLE
pypyr.steps.cmd and pypyr.steps.shell can set working directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -732,14 +732,23 @@ Input context can take one of two forms:
       cmd:
         run: 'echo ${PWD}'
         save: True
+        cwd: './current/working/dir/here'
 
-Be aware that if save is True, all of the command output ends up in memory.
+If ``cwd`` is specified, will change the current working directory to *cwd* to
+execute this command. The directory change is only for the duration of this
+step, not any subsequent steps. If *cwd* is specified, the executable or program
+specified in *run* is relative to the *cwd* if the *run* cmd uses relative paths.
+
+If ``cwd`` is not specified, defaults to the current working directory, which
+is from wherever you are running ``pypyr``.
+
+Be aware that if *save* is True, all of the command output ends up in memory.
 Don't specify it unless your pipeline uses the stdout/stderr response in
 subsequent steps. Keep in mind that if the invoked command return code returns
 a non-zero return code pypyr will automatically raise a *CalledProcessError*
 and stop the pipeline.
 
-If save is True, pypyr will save the output to context as follows:
+If *save* is True, pypyr will save the output to context as follows:
 
 .. code-block:: yaml
 
@@ -2064,8 +2073,17 @@ Input context can take one of two forms:
       cmd:
         run: 'echo ${PWD}'
         save: True
+        cwd: './current/working/dir/here'
 
-Be aware that if save is True, all of the command output ends up in memory.
+If ``cwd`` is specified, will change the current working directory to *cwd* to
+execute this command. The directory change is only for the duration of this
+step, not any subsequent steps. If *cwd* is specified, the executable or program
+specified in *run* is relative to the *cwd* if the *run* cmd uses relative paths.
+
+If ``cwd`` is not specified, defaults to the current working directory, which
+is from wherever you are running ``pypyr``.
+
+Be aware that if *save* is True, all of the command output ends up in memory.
 Don't specify it unless your pipeline uses the stdout/stderr response in
 subsequent steps. Keep in mind that if the invoked command return code returns
 a non-zero return code pypyr will automatically raise a *CalledProcessError*
@@ -2101,9 +2119,11 @@ Friendly reminder of the difference between separating your commands with ; or
   It won't exit with an error code if it wasn't the last statement.
 - && stops and exits reporting error on first error.
 
-You can change directory during this shell step using ``cd``, but dir changes
-are only in scope for subsequent commands in this step, not for subsequent
-steps:
+You can change directory multiple times during this shell step using ``cd``,
+but dir changes are only in scope for subsequent commands in this step, not for
+subsequent steps. Instead prefer using the ``cwd`` input as described above for
+an easy life, which sets the working directory for the entire step without you
+having to code it in with chained shell commands.
 
 .. code-block:: yaml
 

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '2.4.0'
+__version__ = '2.5.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.0
+current_version = 2.5.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/steps/cmd_step_test.py
+++ b/tests/unit/pypyr/steps/cmd_step_test.py
@@ -1,4 +1,5 @@
 """cmd.py unit tests."""
+from pathlib import Path
 import platform
 from pypyr.context import Context
 from pypyr.errors import KeyNotInContextError
@@ -63,6 +64,32 @@ def test_cmd_dict_input_sequence_with_string_interpolation_save_out():
 
     assert context['cmdOut']['returncode'] == 0
     assert context['cmdOut']['stdout'] == 'blah\n'
+    assert not context['cmdOut']['stderr']
+
+
+def test_cmd_dict_input_sequence_with_cwd():
+    """Single command string works with cwd."""
+    context = Context({'fileName': 'deleteinterpolatedme.arb',
+                       'cmd': {'run': 'pwd',
+                               'save': True,
+                               'cwd': './tests'}})
+    pypyr.steps.cmd.run_step(context)
+
+    assert context['cmdOut']['returncode'] == 0
+    assert Path(context['cmdOut']['stdout'].rstrip('\n')).samefile('./tests')
+    assert not context['cmdOut']['stderr']
+
+
+def test_cmd_dict_input_sequence_with_cwd_interpolate():
+    """Single command string works with cwd interpolation."""
+    context = Context({'k1': './tests',
+                       'cmd': {'run': 'pwd',
+                               'save': True,
+                               'cwd': '{k1}'}})
+    pypyr.steps.cmd.run_step(context)
+
+    assert context['cmdOut']['returncode'] == 0
+    assert Path(context['cmdOut']['stdout'].rstrip('\n')).samefile('./tests')
     assert not context['cmdOut']['stderr']
 
 


### PR DESCRIPTION
- use the new `cwd` input on _pypyr.steps.cmd_ and _pypyr.steps.shell_ to set the current working directory for the program/shell that you want to execute. Supports relative paths. 
- bump version to 2.5.0