### PR TITLE
pypyr.steps.now and nowutc closes ref #131

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -527,7 +527,7 @@ Built-in steps
 |                               | expected.                                       |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.cmd`_            | Runs the program and args specified in the      | cmd (string or dict)         |
-|                               | context value `cmd` as a subprocess.            |                              |
+|                               | context value ``cmd`` as a subprocess.          |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.contextclear`_   | Remove specified items from context.            | contextClear (list)          |
 +-------------------------------+-------------------------------------------------+------------------------------+
@@ -549,7 +549,7 @@ Built-in steps
 | `pypyr.steps.default`_        | Set default values in context. Only set values  | defaults (dict)              |
 |                               | if they do not exist already.                   |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.echo`_           | Echo the context value `echoMe` to the output.  | echoMe (string)              |
+| `pypyr.steps.echo`_           | Echo the context value ``echoMe`` to the output.| echoMe (string)              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.env`_            | Get, set or unset $ENVs.                        | env (dict)                   |
 +-------------------------------+-------------------------------------------------+------------------------------+
@@ -576,7 +576,7 @@ Built-in steps
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.pathcheck`_      | Check if path exists on filesystem.             | pathCheck (string or dict)   |
 +-------------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.py`_             | Executes the context value `pycode` as python   | pycode (string)              |
+| `pypyr.steps.py`_             | Executes the context value ``pycode`` as python | pycode (string)              |
 |                               | code.                                           |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.pype`_           | Run another pipeline from within the current    | pype (dict)                  |
@@ -584,9 +584,15 @@ Built-in steps
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.pypyrversion`_   | Writes installed pypyr version to output.       |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.now`_            | Saves current local date/time to context        | nowIn (str)                  |
+|                               | ``now``.                                        |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
+| `pypyr.steps.nowutc`_         | Saves current utc date/time to context          | nowUtcIn (str)               |
+|                               | ``nowUtc``.                                     |                              |
++-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.safeshell`_      | Alias for `pypyr.steps.cmd`_.                   | cmd (string or dict)         |
 +-------------------------------+-------------------------------------------------+------------------------------+
-| `pypyr.steps.shell`_          | Runs the context value `cmd` in the default     | cmd (string or dict)         |
+| `pypyr.steps.shell`_          | Runs the context value ``cmd`` in the default   | cmd (string or dict)         |
 |                               | shell. Use for pipes, wildcards, $ENVs, ~       |                              |
 +-------------------------------+-------------------------------------------------+------------------------------+
 | `pypyr.steps.tar`_            | Archive and/or extract tars with or without     | tar (dict)                   |
@@ -2031,10 +2037,82 @@ pypyr logging format.
 
 Example pipeline yaml:
 
-.. code-block:: bash
+.. code-block:: yaml
 
     steps:
       - pypyr.steps.pypyrversion
+
+pypyr.steps.now
+^^^^^^^^^^^^^^^
+Writes the current local date & time to context *now*. Also known as wall time.
+
+If you want UTC time, check out `pypyr.steps.nowutc`_ instead.
+
+If you run this step as a simple step (with no input *nowIn* formatting), the
+default datetime format is ISO8601. For example:
+*YYYY-MM-DDTHH:MM:SS.ffffff+00:00*
+
+You can use explicit format strings to control the datetime representation. For
+a full list of available formatting codes, check here:
+https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior
+
+.. code-block:: yaml
+
+  - pypyr.steps.now # this sets {now} to YYYY-MM-DDTHH:MM:SS.ffffff+00:00
+  - name: pypyr.steps.echo
+    in:
+      echoMe: 'timestamp in ISO8601 format: {now}'
+  - name: pypyr.steps.now
+    description: use a custom date format string instead of the default ISO8601
+    in:
+      nowIn: '%A %Y %m/%d %H:%M in timezone %Z offset %z, localized to %x'
+  - name: pypyr.steps.echo
+    in:
+      echoMe: 'the custom formatting for now was set in the previous step. {now}'
+  - pypyr.steps.now # subsequent simple step calls will re-use previously set
+                    # nowIn for formatting, but refresh the timestamp.
+
+
+Supports string `Substitutions`_.
+
+See a worked example for `now here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/now.yaml>`__.
+
+pypyr.steps.nowutc
+^^^^^^^^^^^^^^^^^^
+Writes the current UTC date & time to context *nowUtc*.
+
+If you want local or wall time, check out `pypyr.steps.now`_ instead.
+
+If you run this step as a simple step (with no input *nowUtcIn* formatting), the
+default datetime format is ISO8601. For example:
+*YYYY-MM-DDTHH:MM:SS.ffffff+00:00*
+
+You can use explicit format strings to control the datetime representation. For
+a full list of available formatting codes, check here:
+https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior
+
+.. code-block:: yaml
+
+  - pypyr.steps.nowutc # this sets {nowUtc} to YYYY-MM-DDTHH:MM:SS.ffffff+00:00
+  - name: pypyr.steps.echo
+    in:
+      echoMe: 'utc timestamp in ISO8601 format: {nowUtc}'
+  - name: pypyr.steps.nowutc
+    description: use a custom date format string instead of the default ISO8601
+    in:
+      nowUtcIn: '%A %Y %m/%d %H:%M in timezone %Z offset %z, localized to %x'
+  - name: pypyr.steps.echo
+    in:
+      echoMe: 'the custom formatting was set in the previous step: {nowUtc}'
+  - pypyr.steps.nowutc # subsequent simple step calls will re-use previously set
+                       # nowUtcIn for formatting, but refresh the timestamp.
+
+
+Supports string `Substitutions`_.
+
+See a worked example for `nowutc here
+<https://github.com/pypyr/pypyr-example/tree/master/pipelines/now.yaml>`__.
 
 pypyr.steps.safeshell
 ^^^^^^^^^^^^^^^^^^^^^
@@ -2042,7 +2120,7 @@ Alias for `pypyr.steps.cmd`_.
 
 Example pipeline yaml:
 
-.. code-block:: bash
+.. code-block:: yaml
 
   steps:
     - name: pypyr.steps.safeshell

--- a/pypyr/steps/now.py
+++ b/pypyr/steps/now.py
@@ -1,0 +1,43 @@
+"""pypyr step saves the current local datetime to context."""
+from datetime import datetime
+from dateutil.tz import tzlocal
+import logging
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """pypyr step saves current local datetime to context.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context key is optional:
+                - nowIn. str. Datetime formatting expression. For full list of
+                  possible expressions, check here:
+                  https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior
+
+    All inputs support pypyr formatting expressions.
+
+    This step creates now in context, containing a string representation of the
+    timestamp. If input formatting not specified, defaults to ISO8601.
+
+    Default is:
+    YYYY-MM-DDTHH:MM:SS.ffffff, or, if microsecond is 0, YYYY-MM-DDTHH:MM:SS
+
+    Returns:
+        None. updates context arg.
+
+    """
+    logger.debug("started")
+
+    format_expression = context.get('nowIn', None)
+
+    if format_expression:
+        formatted_expression = context.get_formatted_string(format_expression)
+        context['now'] = datetime.now(tzlocal()).strftime(formatted_expression)
+    else:
+        context['now'] = datetime.now(tzlocal()).isoformat()
+
+    logger.info(f"timestamp {context['now']} saved to context now")
+    logger.debug("done")

--- a/pypyr/steps/nowutc.py
+++ b/pypyr/steps/nowutc.py
@@ -1,0 +1,44 @@
+"""pypyr step saves the current utc datetime to context."""
+from datetime import datetime, timezone
+import logging
+
+# logger means the log level will be set correctly
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """pypyr step saves current utc datetime to context.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context key is optional:
+                - nowUtcIn. str. Datetime formatting expression. For full list
+                  of possible expressions, check here:
+                  https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior
+
+    All inputs support pypyr formatting expressions.
+
+    This step creates now in context, containing a string representation of the
+    timestamp. If input formatting not specified, defaults to ISO8601.
+
+    Default is:
+    YYYY-MM-DDTHH:MM:SS.ffffff+00:00, or, if microsecond is 0,
+    YYYY-MM-DDTHH:MM:SS
+
+    Returns:
+        None. updates context arg.
+
+    """
+    logger.debug("started")
+
+    format_expression = context.get('nowUtcIn', None)
+
+    if format_expression:
+        formatted_expression = context.get_formatted_string(format_expression)
+        context['nowUtc'] = datetime.now(
+            timezone.utc).strftime(formatted_expression)
+    else:
+        context['nowUtc'] = datetime.now(timezone.utc).isoformat()
+
+    logger.info(f"timestamp {context['nowUtc']} saved to context nowUtc")
+    logger.debug("done")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '2.5.0'
+__version__ = '2.6.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.6.0
 
 [bdist_wheel]
 universal = 0

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['ruamel.yaml'],
+    install_requires=['python-dateutil', 'ruamel.yaml'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/unit/pypyr/steps/now_test.py
+++ b/tests/unit/pypyr/steps/now_test.py
@@ -1,0 +1,49 @@
+"""now.py unit tests."""
+from datetime import datetime
+from dateutil.tz import tzlocal
+from unittest.mock import patch, Mock
+from pypyr.context import Context
+import pypyr.steps.now as now_step
+
+frozen_timestamp = datetime.now(tzlocal())
+
+
+@patch('pypyr.steps.now.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_now_default_iso():
+    """Now gets date in iso format."""
+    context = Context()
+    now_step.run_step(context)
+
+    assert context['now'] == frozen_timestamp.isoformat()
+
+
+@patch('pypyr.steps.now.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_now_with_formatting_date_part():
+    """Now gets timestamp with formatting."""
+    context = Context({'nowIn': '%Y%m%d'})
+    now_step.run_step(context)
+
+    assert context['now'] == frozen_timestamp.strftime('%Y%m%d')
+
+
+@patch('pypyr.steps.now.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_now_with_formatting_time_part():
+    """Now gets timestamp with formatting."""
+    context = Context({'nowIn': '%I hour %M %p blah %Z'})
+    now_step.run_step(context)
+
+    assert context['now'] == frozen_timestamp.strftime(
+        '%I hour %M %p blah %Z')
+
+
+@patch('pypyr.steps.now.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_now_with_formatting_interpolation():
+    """Now gets timestamp with date formatting and pypyr interpolation."""
+    context = Context({'f': '%Y %w', 'nowIn': '%A {f}'})
+    now_step.run_step(context)
+
+    assert context['now'] == frozen_timestamp.strftime('%A %Y %w')

--- a/tests/unit/pypyr/steps/nowutc_test.py
+++ b/tests/unit/pypyr/steps/nowutc_test.py
@@ -1,0 +1,48 @@
+"""nowutc.py unit tests."""
+from datetime import datetime, timezone
+from unittest.mock import patch, Mock
+from pypyr.context import Context
+import pypyr.steps.nowutc as nowutc_step
+
+frozen_timestamp = datetime.now(timezone.utc)
+
+
+@patch('pypyr.steps.nowutc.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_nowutc_default_iso():
+    """Now gets date in iso format."""
+    context = Context()
+    nowutc_step.run_step(context)
+
+    assert context['nowUtc'] == frozen_timestamp.isoformat()
+
+
+@patch('pypyr.steps.nowutc.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_nowutc_with_formatting_date_part():
+    """Now gets timestamp with formatting."""
+    context = Context({'nowUtcIn': '%Y%m%d'})
+    nowutc_step.run_step(context)
+
+    assert context['nowUtc'] == frozen_timestamp.strftime('%Y%m%d')
+
+
+@patch('pypyr.steps.nowutc.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_nowutc_with_formatting_time_part():
+    """Now gets timestamp with date formatting."""
+    context = Context({'nowUtcIn': '%I hour %M %p blah %Z'})
+    nowutc_step.run_step(context)
+
+    assert context['nowUtc'] == frozen_timestamp.strftime(
+        '%I hour %M %p blah UTC')
+
+
+@patch('pypyr.steps.nowutc.datetime',
+       Mock(now=Mock(return_value=frozen_timestamp)))
+def test_nowutc_with_formatting_interpolation():
+    """Now gets timestamp with date formatting and pypyr interpolation."""
+    context = Context({'f': '%Y %w', 'nowUtcIn': '%A {f}'})
+    nowutc_step.run_step(context)
+
+    assert context['nowUtc'] == frozen_timestamp.strftime('%A %Y %w')


### PR DESCRIPTION
- get the current datetime stamp into the pypyr context as a formattable string, where you can specify your own datetime formats using the standard python date time replacement tokens like '%Y-%m-%d' for YYYY-MM-DD.
- adds python-dateutil as setup dependency