### PR TITLE
RetryDecorator and while loop stop condition until style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -365,6 +365,9 @@ Don't bother specifying these unless you want to deviate from the default values
         parameter1: value1
         parameter2: value2
       foreach: [] # optional. Repeat the step once for each item in this list.
+      retry: # optional. Retry step until it doesn't raise an error.
+        max: 1 # max times to retry. integer. Defaults None (infinite).
+        sleep: 0 # sleep between retries, in seconds. Decimals allowed. Defaults 0.
       run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
       skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
       swallow: False # optional. Swallows any errors raised by the step. Defaults to False if not specified.
@@ -394,6 +397,15 @@ Don't bother specifying these unless you want to deviate from the default values
 |               |          | execution, before the *foreach* and *while* |                |
 |               |          | decorators. It does not re-evaluate for each|                |
 |               |          | loop iteration.                             |                |
++---------------+----------+---------------------------------------------+----------------+
+| retry         | dict     | Retries the step until it doesn't error.    | None           |
+|               |          | The retry iteration counter is              |                |
+|               |          | ``context['retryCounter']``.                |                |
+|               |          |                                             |                |
+|               |          | If you reach *max* while the step still     |                |
+|               |          | errors, will raise the last error and stop  |                |
+|               |          | further pipeline processing, unless         |                |
+|               |          | *swallow* is True.                          |                |
 +---------------+----------+---------------------------------------------+----------------+
 | run           | bool     | Runs this step if True, skips step if       | True           |
 |               |          | False.                                      |                |
@@ -463,6 +475,8 @@ Decorators can interplay, meaning that the sequence of evaluation is important.
 - *swallow* can evaluate dynamically inside a loop to decide whether to swallow
   an error or not on a particular iteration.
 
+- *swallow* can swallow an error after *retry* exhausted max attempts.
+
 .. code-block:: yaml
 
   in # in evals once and only once at the beginning of step
@@ -470,8 +484,9 @@ Decorators can interplay, meaning that the sequence of evaluation is important.
       -> foreach # everything below loops inside foreach
         -> run # evals dynamically on each loop iteration
          -> skip # evals dynamically on each loop iteration after run
+          -> retry # repeats step execution until no error
             [>>>actual step execution here<<<]
-              -> swallow # evaluated dynamically on each loop iteration
+          -> swallow # evaluated dynamically on each loop iteration
 
 Decorator examples
 ^^^^^^^^^^^^^^^^^^
@@ -486,6 +501,8 @@ Decorator examples
 +------------------------------------------------+-----------------------------+
 | foreach with dynamic conditional decorator     | |foreach-dynamic|           |
 | evaluation.                                    |                             |
++------------------------------------------------+-----------------------------+
+| retry                                          | |retry-decorator|           |
 +------------------------------------------------+-----------------------------+
 | while looping                                  | |while-decorator|           |
 +------------------------------------------------+-----------------------------+
@@ -506,6 +523,8 @@ Decorator examples
 .. |foreach-decorator| replace:: `foreach <https://github.com/pypyr/pypyr-example/blob/master/pipelines/foreach.yaml>`__
 
 .. |foreach-dynamic| replace:: `foreach dynamic conditionals <https://github.com/pypyr/pypyr-example/blob/master/pipelines/foreachconditionals.yaml>`__
+
+.. |retry-decorator| replace:: `retry decorator <https://github.com/pypyr/pypyr-example/blob/master/pipelines/retry.yaml>`__
 
 .. |while-decorator| replace:: `while decorator <https://github.com/pypyr/pypyr-example/blob/master/pipelines/while.yaml>`__
 

--- a/README.rst
+++ b/README.rst
@@ -527,6 +527,10 @@ Decorator examples
 +------------------------------------------------+-----------------------------+
 | retry                                          | |retry-decorator|           |
 +------------------------------------------------+-----------------------------+
+| retry with retryOn                             | |retry-decorator-retryon|   |
++------------------------------------------------+-----------------------------+
+| retry with stopOn                              | |retry-decorator-stopon|    |
++------------------------------------------------+-----------------------------+
 | while looping                                  | |while-decorator|           |
 +------------------------------------------------+-----------------------------+
 | while with sleep intervals                     | |while-sleep|               |
@@ -548,6 +552,10 @@ Decorator examples
 .. |foreach-dynamic| replace:: `foreach dynamic conditionals <https://github.com/pypyr/pypyr-example/blob/master/pipelines/foreachconditionals.yaml>`__
 
 .. |retry-decorator| replace:: `retry decorator <https://github.com/pypyr/pypyr-example/blob/master/pipelines/retry.yaml>`__
+
+.. |retry-decorator-retryon| replace:: `retry decorator retryOn <https://github.com/pypyr/pypyr-example/blob/master/pipelines/retryontypes.yaml>`__
+
+.. |retry-decorator-stopon| replace:: `retry decorator stopOn <https://github.com/pypyr/pypyr-example/blob/master/pipelines/retrystopon.yaml>`__
 
 .. |while-decorator| replace:: `while decorator <https://github.com/pypyr/pypyr-example/blob/master/pipelines/while.yaml>`__
 

--- a/README.rst
+++ b/README.rst
@@ -368,6 +368,8 @@ Don't bother specifying these unless you want to deviate from the default values
       retry: # optional. Retry step until it doesn't raise an error.
         max: 1 # max times to retry. integer. Defaults None (infinite).
         sleep: 0 # sleep between retries, in seconds. Decimals allowed. Defaults 0.
+        stopOn: ['ValueError', 'MyModule.SevereError'] # Stop retry on these errors. Defaults None (retry all).
+        retryOn: ['TimeoutError'] # Only retry these errors. Defaults None (retry all).
       run: True # optional. Runs this step if True, skips step if False. Defaults to True if not specified.
       skip: False # optional. Skips this step if True, runs step if False. Defaults to False if not specified.
       swallow: False # optional. Swallows any errors raised by the step. Defaults to False if not specified.
@@ -406,6 +408,27 @@ Don't bother specifying these unless you want to deviate from the default values
 |               |          | errors, will raise the last error and stop  |                |
 |               |          | further pipeline processing, unless         |                |
 |               |          | *swallow* is True.                          |                |
+|               |          |                                             |                |
+|               |          | When neither *stopOn* and *retryOn* set,    |                |
+|               |          | all types of errors will retry.             |                |
+|               |          |                                             |                |
+|               |          | If *stopOn* is specified, errors listed     |                |
+|               |          | in *stopOn* will stop retry processing and  |                |
+|               |          | raise an error. Errors not listed in        |                |
+|               |          | *stopOn* will retry.                        |                |
+|               |          |                                             |                |
+|               |          | If *retryOn* is specified, ONLY errors      |                |
+|               |          | listed in *retryOn* will retry.             |                |
+|               |          |                                             |                |
+|               |          | *max* evaluates before *stopOn* and         |                |
+|               |          | *retryOn*. *stopOn* supersedes *retryOn*.   |                |
+|               |          |                                             |                |
+|               |          | For builtin python errors, specify the bare |                |
+|               |          | error name for *stopOn* and *retryOn*, e.g  |                |
+|               |          | 'ValueError', 'KeyError'.                   |                |
+|               |          |                                             |                |
+|               |          | For all other errors, use module.errorname, |                |
+|               |          | e.g 'mypackage.mymodule.myerror'            |                |
 +---------------+----------+---------------------------------------------+----------------+
 | run           | bool     | Runs this step if True, skips step if       | True           |
 |               |          | False.                                      |                |

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -239,6 +239,12 @@ class Step:
             self.name = step
 
         self.module = pypyr.moduleloader.get_module(self.name)
+        try:
+            self.run_step_function = getattr(self.module, 'run_step')
+        except AttributeError:
+            logger.error(f"The step {self.name} in module {self.module} "
+                         "doesn't have a run_step(context) function.")
+            raise
 
         logger.debug("done")
 
@@ -290,16 +296,11 @@ class Step:
         """
         logger.debug("starting")
 
-        try:
-            logger.debug(f"running step {self.module}")
+        logger.debug(f"running step {self.module}")
 
-            self.module.run_step(context)
+        self.run_step_function(context)
 
-            logger.debug(f"step {self.module} done")
-        except AttributeError:
-            logger.error(f"The step {self.name} doesn't have a "
-                         "run_step(context) function.")
-            raise
+        logger.debug(f"step {self.module} done")
 
     def run_conditional_decorators(self, context):
         """Evaluate the step decorators to decide whether to run step or not.

--- a/pypyr/errors.py
+++ b/pypyr/errors.py
@@ -4,6 +4,29 @@ All pypyr specific exceptions derive from Error.
 """
 
 
+def get_error_name(error):
+    """Return canonical error name as string.
+
+    For builtin errors like ValueError or Exception, will return the bare
+    name, like ValueError or Exception.
+
+    For all other exceptions, will return modulename.errorname, such as
+    arbpackage.mod.myerror
+
+    Args:
+        error: Exception object.
+
+    Returns:
+        str. Canonical error name.
+
+    """
+    error_type = type(error)
+    if error_type.__module__ in ['__main__', 'builtins']:
+        return error_type.__name__
+    else:
+        return f'{error_type.__module__}.{error_type.__name__}'
+
+
 class Error(Exception):
     """Base class for all pypyr exceptions."""
 
@@ -18,6 +41,7 @@ class KeyInContextHasNoValueError(ContextError):
 
 class KeyNotInContextError(ContextError, KeyError):
     """Key not found in the pypyr context."""
+
     def __str__(self):
         """KeyError has custom error formatting, avoid this behaviour."""
         return super(Exception, self).__str__()

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '2.7.0'
+__version__ = '2.8.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.7.0
+current_version = 2.8.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyr/errors_test.py
+++ b/tests/unit/pypyr/errors_test.py
@@ -2,6 +2,7 @@
 from pypyr.errors import Error as PypyrError
 from pypyr.errors import (
     ContextError,
+    get_error_name,
     KeyInContextHasNoValueError,
     KeyNotInContextError,
     LoopMaxExhaustedError,
@@ -10,6 +11,16 @@ from pypyr.errors import (
     PipelineNotFoundError,
     PyModuleNotFoundError)
 import pytest
+
+
+def test_get_error_name_builtin():
+    """Builtin returns bare name on get_error_name."""
+    assert get_error_name(ValueError('blah')) == 'ValueError'
+
+
+def test_get_error_name_canonical():
+    """Other error returns modulename.name on get_error_name."""
+    assert get_error_name(ContextError('blah')) == 'pypyr.errors.ContextError'
 
 
 def test_base_error_raises():

--- a/tests/unit/pypyr/stepsrunner_test.py
+++ b/tests/unit/pypyr/stepsrunner_test.py
@@ -10,6 +10,11 @@ import pypyr.stepsrunner
 # ------------------------- test context--------------------------------------#
 
 
+def arb_step_mock(context):
+    """No real reason, other than to mock the existence of a run_step."""
+    return 'from arb step mock'
+
+
 def get_test_context():
     """Return a pypyr context for testing."""
     return Context({
@@ -149,7 +154,7 @@ def test_run_pipeline_steps_none():
     mock_logger_debug.assert_any_call("No steps found to execute.")
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_complex(mock_invoke_step, mock_module):
     """Complex step run with no in args."""
@@ -162,7 +167,7 @@ def test_run_pipeline_steps_complex(mock_invoke_step, mock_module):
     mock_invoke_step.assert_called_once_with(context={'k1': 'v1'})
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_complex_with_in(mock_invoke_step, mock_module):
     """Complex step run with in args. In args added to context for run_step."""
@@ -200,7 +205,7 @@ def test_run_pipeline_steps_complex_with_in(mock_invoke_step, mock_module):
 # -----------------------  run_pipeline_steps: run ---------------------------#
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_mix_run_and_not_run(mock_invoke_step, mock_module):
     """Complex steps, some run some don't."""
@@ -267,7 +272,7 @@ def test_run_pipeline_steps_mix_run_and_not_run(mock_invoke_step, mock_module):
     assert len(context) == original_len
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_complex_with_multistep_none_run(mock_invoke_step,
                                                             mock_module):
@@ -309,7 +314,7 @@ def test_run_pipeline_steps_complex_with_multistep_none_run(mock_invoke_step,
 # -----------------------  run_pipeline_steps: skip --------------------------#
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_mix_skip_and_not_skip(mock_invoke_step,
                                                   mock_module):
@@ -377,7 +382,7 @@ def test_run_pipeline_steps_mix_skip_and_not_skip(mock_invoke_step,
     assert len(context) == original_len
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_complex_with_multistep_all_skip(mock_invoke_step,
                                                             mock_module):
@@ -428,7 +433,7 @@ def test_run_pipeline_steps_complex_with_multistep_all_skip(mock_invoke_step,
 # -----------------------  run_pipeline_steps: swallow -----------------------#
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'invoke_step')
 def test_run_pipeline_steps_swallow_sequence(mock_invoke_step, mock_module):
     """Complex steps, some run some don't, some swallow, some don't."""
@@ -556,7 +561,7 @@ def test_run_pipeline_steps_swallow_sequence(mock_invoke_step, mock_module):
 # ------------------------- run_pipeline_steps--------------------------------#
 
 
-@patch('pypyr.moduleloader.get_module', return_value='arbmodule')
+@patch('pypyr.moduleloader.get_module')
 @patch.object(Step, 'run_step')
 def test_run_pipeline_steps_simple(mock_run_step, mock_module):
     """Simple step run."""


### PR DESCRIPTION
- new Retry decorator allows steps to retry automatically when step encounters an error. ref #130 
- fix run_step AttributeError might have caught or hidden AttributeErrors in the step code itself, rather than just when the step module didn't contain a run_step function. ref #129
- while loop checks `stop` condition only at end of each iteration. previously if a stop condition evaluated True even before the loop started the loop wouldn't run at all. now the loop will run once. If you don't want the step to run, use the `skip: True` decorator instead.
- documentation updates for all the above
- version bump for new release.