### PR TITLE
friendlier error message on import errors

### DIFF
--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -41,18 +41,26 @@ def get_module(module_abs_import):
         logger.debug("done")
         return imported_module
     except ModuleNotFoundError as err:
-        extended_msg = (f"{module_abs_import}.py should be in your working "
-                        "dir or it should be installed to the python path."
-                        "\nIf you have 'package.sub.mod' your current working "
-                        "dir should contain ./package/sub/mod.py\n"
-                        "If you specified 'mymodulename', your current "
-                        "working dir should contain ./mymodulename.py\n"
-                        "If the module is not in your current working dir, it "
-                        "must exist in your current python path - so you "
-                        "should have run pip install or setup.py")
-        logger.error("The module doesn't exist. "
-                     "Looking for a file like this: %s",
-                     module_abs_import)
+        if err.name != module_abs_import:
+            extended_msg = (
+                f'error importing module {err.name} in {module_abs_import}')
+            logger.error("Couldn't import module %s in this module: %s",
+                         err.name,
+                         module_abs_import)
+        else:
+            extended_msg = (
+                f"{module_abs_import}.py should be in your working "
+                "dir or it should be installed to the python path."
+                "\nIf you have 'package.sub.mod' your current working "
+                "dir should contain ./package/sub/mod.py\n"
+                "If you specified 'mymodulename', your current "
+                "working dir should contain ./mymodulename.py\n"
+                "If the module is not in your current working dir, it "
+                "must exist in your current python path - so you "
+                "should have run pip install or setup.py")
+            logger.error("The module doesn't exist. "
+                         "Looking for a file like this: %s",
+                         module_abs_import)
         raise PyModuleNotFoundError(extended_msg) from err
 
 

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.0.2
 
 [bdist_wheel]
 universal = 0

--- a/tests/arbpack/arbinvalidimportmod.py
+++ b/tests/arbpack/arbinvalidimportmod.py
@@ -1,0 +1,10 @@
+"""Module will not import due to invalid blahblah import."""
+import blahblah.blah
+
+
+print("I dont do much")
+
+
+def arbmodinvalid_attribute():
+    """Can't ever run on account of how blah doesn't exist."""
+    blahblah.blah.blah()


### PR DESCRIPTION
* When importing a step that does exist (`mystep.blah`), a failing `import mymodule.blah` inside `mystep.blah` would give a misleading error and hide the actual source of the problem. Fixes #166
* version bump for release 