### PR TITLE
Allow formatting & merging on non-string keys on Mapping objects

### DIFF
--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '3.2.0'
+__version__ = '3.2.1'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 
 [bdist_wheel]
 universal = 0


### PR DESCRIPTION
- Allow non-string keys on `context.get_formatted_iterable` and context merge (including `pypyr.steps.contextmerge`). Resolves #179.
- Version bump for patch release