### PR TITLE
Context formatter: add support for read-only mapping

### DIFF
--- a/pypyr/context.py
+++ b/pypyr/context.py
@@ -349,10 +349,13 @@ class Context(dict):
             new = obj
         elif isinstance(obj, Mapping):
             # dicts
-            new = obj.__class__()
-            for k, v in obj.items():
-                new[self.get_formatted_value(
-                    k)] = self.get_formatted_iterable(v, memo)
+            new = obj.__class__(
+                (
+                    self.get_formatted_value(k),
+                    self.get_formatted_iterable(v, memo)
+                )
+                for k, v in obj.items()
+            )
         elif isinstance(obj, (Sequence, Set)):
             # list, set, tuple. Bytes and str won't fall into this branch coz
             # they're expicitly checked further up in the if.

--- a/tests/unit/pypyr/context_test.py
+++ b/tests/unit/pypyr/context_test.py
@@ -7,6 +7,7 @@ from pypyr.errors import (
     KeyInContextHasNoValueError,
     KeyNotInContextError)
 import pytest
+import typing
 
 # ------------------- behaves like a dictionary-------------------------------#
 
@@ -682,6 +683,34 @@ def test_get_formatted_iterable_set():
     diffs = output - input_obj
     assert len(diffs) == 1
     assert 'ctxvalue3' in diffs
+
+
+def test_get_formatted_immutable_mapping():
+    """Simple read-only mapping test."""
+
+    class ReadOnlyMapping(typing.Mapping):
+        def __init__(self, *args, **kwargs):
+            self._data = dict(*args, **kwargs)
+
+        def __getitem__(self, key):
+            return self._data[key]
+
+        def __len__(self):
+            return len(self._data)
+
+        def __iter__(self):
+            return iter(self._data)
+
+    input_obj = {'key': '{ctx}'}
+
+    context = Context(
+        {'ctx': ReadOnlyMapping({'arb': 1})})
+
+    output = context.get_formatted_iterable(input_obj)
+
+    assert output is not input_obj
+    assert isinstance(output['key'], ReadOnlyMapping)
+    assert output['key'] == {'arb': 1}
 
 
 def test_get_formatted_iterable_nested():


### PR DESCRIPTION
Add support for immutable dict types such as `immutables.Map`, `multidict.MultiDictProxy` typing. Resolves #181 